### PR TITLE
Made URL resolution more robust

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 const (
@@ -59,7 +60,7 @@ func NewClient(token string) (Client, error) {
 }
 
 func NewClientWithBaseUrl(token string, baseUrl string) (Client, error) {
-	baseURL, _ := url.Parse(baseUrl)
+	baseURL := toURLWithEndingSlash(baseUrl)
 	httpClient := http.Client{}
 
 	client := &client{client: &httpClient, baseURL: baseURL, token: token}
@@ -73,6 +74,14 @@ func NewClientWithBaseUrl(token string, baseUrl string) (Client, error) {
 	client.verification = (*VerificationService)(commonService)
 
 	return client, nil
+}
+
+func toURLWithEndingSlash(u string) *url.URL {
+	baseURL, _ := url.Parse(u)
+	if !strings.HasSuffix(baseURL.Path, "/") {
+		baseURL.Path += "/"
+	}
+	return baseURL
 }
 
 // NewRequestWithBody creates an API request.

--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -60,10 +60,14 @@ func NewClient(token string) (Client, error) {
 }
 
 func NewClientWithBaseUrl(token string, baseUrl string) (Client, error) {
-	baseURL := toURLWithEndingSlash(baseUrl)
 	httpClient := http.Client{}
 
-	client := &client{client: &httpClient, baseURL: baseURL, token: token}
+	return NewClientWithCustomHTTP(token, baseUrl, &httpClient)
+}
+
+func NewClientWithCustomHTTP(token string, urlStr string, httpClient *http.Client) (Client, error) {
+	baseURL := toURLWithEndingSlash(urlStr)
+	client := &client{client: httpClient, baseURL: baseURL, token: token}
 
 	commonService := &service{client: client}
 	client.clients = (*ClientsService)(commonService)

--- a/clerk/clerk_test.go
+++ b/clerk/clerk_test.go
@@ -20,6 +20,15 @@ func TestNewClient_baseUrl(t *testing.T) {
 	}
 }
 
+func TestNewClient_baseUrlWithoutSlash(t *testing.T) {
+	input, want := "http://host/v1", "http://host/v1/"
+	c, _ := NewClientWithBaseUrl("token", input)
+
+	if got := c.(*client).baseURL.String(); got != want {
+		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
+	}
+}
+
 func TestNewClient_createsDifferentClients(t *testing.T) {
 	token := "token"
 	c, _ := NewClient(token)


### PR DESCRIPTION
# Title

<!--- Provide a general summary of your changes in the Title above -->

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

With the previous implementation, if the given URL was not ending with `/`, then the SDK would remove the final path. This is now fixed, when creating the client, we check if the given URL has a trailing `/` and if not, we add one.

There is also an additional function to create the `clerk.Client` which allows you to specify the HTTP Client you want it to use. For example, a user might want to use a client which offers some caching.

### Related Issue (optional)

<!--- Please link to the issue here: -->
