### PR TITLE
Verification relies solely on existence of _clerk_session_id

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,3 @@
-# Title
-
-<!--- Provide a general summary of your changes in the Title above -->
-
 ## Type of change
 
 <!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,4 +46,6 @@ jobs:
       - name: Run integration tests
         env:
           CLERK_API_KEY: ${{ secrets.CLERK_API_KEY }}
+          CLERK_SESSION_TOKEN: ${{ secrets.CLERK_SESSION_TOKEN }}
+          CLERK_SESSION_ID: ${{ secrets.CLERK_SESSION_ID }}
         run: go test -tags=integration ./tests/integration

--- a/clerk/verification.go
+++ b/clerk/verification.go
@@ -2,14 +2,12 @@ package clerk
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 )
 
 const (
 	CookieSession       = "__session"
 	QueryParamSessionId = "_clerk_session_id"
-	OriginHeader        = "Origin"
 )
 
 type VerificationService service
@@ -30,21 +28,11 @@ func (s *VerificationService) Verify(req *http.Request) (*Session, error) {
 	sessionToken := cookie.Value
 	sessionId := req.URL.Query().Get(QueryParamSessionId)
 
-	if !isXHR(req) && req.Method == "GET" && sessionId == "" {
+	if sessionId == "" {
 		return s.useClientActiveSession(sessionToken)
 	}
 
-	if sessionId == "" {
-		return nil, errors.New(fmt.Sprintf("no session id is specified via the %s query parameter", QueryParamSessionId))
-	}
-
 	return s.client.Sessions().Verify(sessionId, sessionToken)
-}
-
-func isXHR(req *http.Request) bool {
-	headers := req.Header
-	origin := headers.Get(OriginHeader)
-	return len(origin) > 0
 }
 
 func (s *VerificationService) useClientActiveSession(token string) (*Session, error) {

--- a/clerk/verification_test.go
+++ b/clerk/verification_test.go
@@ -115,20 +115,6 @@ func TestVerificationService_Verify_handleServerErrorWhenUsingClientActiveSessio
 	}
 }
 
-func TestVerificationService_Verify_returnErrorWhenUsingClientActiveSessionForXHR(t *testing.T) {
-	sessionToken := "someSessionToken"
-	request := setupRequest(nil, &sessionToken)
-	request.Header.Add(OriginHeader, "someOrigin")
-
-	client, _, _, teardown := setup("apiToken")
-	defer teardown()
-
-	_, err := client.Verification().Verify(request)
-	if err == nil {
-		t.Errorf("Was expecting error to be returned")
-	}
-}
-
 func TestVerificationService_Verify_noActiveSessionWhenUsingClientActiveSession(t *testing.T) {
 	apiToken := "apiToken"
 	sessionToken := "someSessionToken"

--- a/tests/integration/clerk_test.go
+++ b/tests/integration/clerk_test.go
@@ -7,15 +7,27 @@ import (
 	"os"
 )
 
-func createClient() clerk.Client {
-	apiKey := os.Getenv("CLERK_API_KEY")
-	if apiKey == "" {
-		panic("Missing env variable CLERK_API_KEY")
-	}
+type key string
 
+const (
+	APIKey       = "CLERK_API_KEY"
+	SessionToken = "CLERK_SESSION_TOKEN"
+	SessionID    = "CLERK_SESSION_ID"
+)
+
+func createClient() clerk.Client {
+	apiKey := getEnv(APIKey)
 	client, err := clerk.NewClient(apiKey)
 	if err != nil {
 		panic("Unable to create Clerk client")
 	}
 	return client
+}
+
+func getEnv(k string) string {
+	envValue := os.Getenv(k)
+	if envValue == "" {
+		panic("Missing env variable " + k)
+	}
+	return envValue
 }

--- a/tests/integration/verification_test.go
+++ b/tests/integration/verification_test.go
@@ -27,7 +27,7 @@ func TestVerification_clientActiveSession(t *testing.T) {
 func TestVerification_verifySessionId(t *testing.T) {
 	client := createClient()
 
-	sessionId := "sess_1n8u0DZwnk3N4X9iDZ4eSxPfwQ0"
+	sessionId := getEnv(SessionID)
 	request := buildRequest(&sessionId)
 
 	session, err := client.Verification().Verify(request)
@@ -39,8 +39,6 @@ func TestVerification_verifySessionId(t *testing.T) {
 		t.Errorf("Was expecting session to be returned")
 	}
 }
-
-const dummySessionToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJkZXYiOiJkdmJfMW44dHNvcWh6QkdBSTAwNWRVSXQ0YUNPbXhwIiwiaWQiOiJjbGllbnRfMW44dHpCZzZPMFV0bDIzQUxzSnNPOHd6UGltIiwicm90YXRpbmdfdG9rZW4iOiI5ZjJ2c2pocGhtb3J3enZ0ZXRhNGt5YjVjODViMDZtYzg0emI4ZHM1In0.03WXffBCv8MmRRqx_GzfKcpo8tPQ12gx8eZ_v7w2thZJmLPL-5N_-dFSDICpP2_0gOErnl9NKhFDjgC6TPpery0sLzNqSpxc12gb0VWJlYP78vI5daF8aqhUzefTY3buwFsSLJrdm1nxQViWBGc7HEJGsLvD5sYZxF1OYzi7eOy2k-k6ASFAg3CGJnjBmZy-jhUzgjntbflekfaSfBeYgWpWsuVXwieZ6ZdEeaypTQ20VZzAvhFX-TZocyf3p2aIS9yZRf5OL2n5p8Vy8yLoxhrkP9TWf7k6et7O3gKLaq4ym7cZL_iFOOiMOAIZcXWTfe37F6VA4qaNsUaVvd74Sg"
 
 func buildRequest(sessionId *string) *http.Request {
 	var request http.Request
@@ -56,7 +54,7 @@ func buildRequest(sessionId *string) *http.Request {
 	// add session token as cookie
 	sessionCookie := http.Cookie{
 		Name:  clerk.CookieSession,
-		Value: dummySessionToken,
+		Value: getEnv(SessionToken),
 	}
 	request.Header = make(map[string][]string)
 	request.AddCookie(&sessionCookie)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Modified verification algorithm to rely solely on the existence of `_clerk_session_id` query parameter.

In particular:
* If `_clerk_session_id` is missing, use last active session
* If `_clerk_session_id` is present use the given session

### Related Issue (optional)

https://www.notion.so/clerkdev/Align-Go-SDK-middleware-with-Node-SDK-middleware-5b12e9e63627486d8678df5d1df129e6
