### PR TITLE
Users can have custom public and private metadata

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Run integration tests
         env:
+          CLERK_API_URL: ${{ secrets.CLERK_API_URL }}
           CLERK_API_KEY: ${{ secrets.CLERK_API_KEY }}
           CLERK_SESSION_TOKEN: ${{ secrets.CLERK_SESSION_TOKEN }}
           CLERK_SESSION_ID: ${{ secrets.CLERK_SESSION_ID }}

--- a/clerk/users.go
+++ b/clerk/users.go
@@ -22,8 +22,8 @@ type User struct {
 	EmailAddresses        []EmailAddress `json:"email_addresses"`
 	PhoneNumbers          []PhoneNumber  `json:"phone_numbers"`
 	ExternalAccounts      []interface{}  `json:"external_accounts"`
-	Metadata              interface{}    `json:"metadata"`
-	PrivateMetadata       interface{}    `json:"private_metadata,omitempty"`
+	PublicMetadata        interface{}    `json:"public_metadata"`
+	PrivateMetadata       interface{}    `json:"private_metadata"`
 	CreatedAt             int64          `json:"created_at"`
 	UpdatedAt             int64          `json:"updated_at"`
 }
@@ -91,12 +91,14 @@ func (s *UsersService) Delete(userId string) (*DeleteResponse, error) {
 }
 
 type UpdateUser struct {
-	FirstName             *string `json:"first_name,omitempty"`
-	LastName              *string `json:"last_name,omitempty"`
-	PrimaryEmailAddressID *string `json:"primary_email_address_id,omitempty"`
-	PrimaryPhoneNumberID  *string `json:"primary_phone_number_id,omitempty"`
-	ProfileImage          *string `json:"profile_image,omitempty"`
-	Password              *string `json:"password,omitempty"`
+	FirstName             *string     `json:"first_name,omitempty"`
+	LastName              *string     `json:"last_name,omitempty"`
+	PrimaryEmailAddressID *string     `json:"primary_email_address_id,omitempty"`
+	PrimaryPhoneNumberID  *string     `json:"primary_phone_number_id,omitempty"`
+	ProfileImage          *string     `json:"profile_image,omitempty"`
+	Password              *string     `json:"password,omitempty"`
+	PublicMetadata        interface{} `json:"public_metadata,omitempty"`
+	PrivateMetadata       interface{} `json:"private_metadata,omitempty"`
 }
 
 func (s *UsersService) Update(userId string, updateRequest *UpdateUser) (*User, error) {

--- a/clerk/users_test.go
+++ b/clerk/users_test.go
@@ -184,17 +184,24 @@ const dummyUserJson = `{
         "gender": "",
         "id": "user_1mebQggrD3xO5JfuHk7clQ94ysA",
         "last_name": "Stark",
-        "metadata": {},
         "object": "user",
         "password_enabled": false,
         "phone_numbers": [],
         "primary_email_address_id": "idn_1n8tzqi8K5ydvb1K7RJEKjT7Wb8",
         "primary_phone_number_id": null,
-        "private_metadata": {},
         "profile_image_url": "https://lh3.googleusercontent.com/a-/AOh14Gg-UlYe7PzddYKJRu2r8vGTn7cqxx=s96-c",
         "two_factor_enabled": false,
         "updated_at": 1610783813,
-        "username": null
+        "username": null,
+		"public_metadata": {
+			"address": {
+				"street": "Pennsylvania Avenue",
+				"number": "1600"
+			}
+		},
+		"private_metadata": {
+			"app_id": 5
+		}
     }`
 
 const dummyUpdateRequestJson = `{
@@ -203,5 +210,14 @@ const dummyUpdateRequestJson = `{
 		"primary_email_address_id": "some_image_id",
 		"primary_phone_number_id": "some_phone_id",
 		"profile_image": "some_profile_image",
-		"password": "new_password"
+		"password": "new_password",
+		"public_metadata": {
+			"address": {
+				"street": "Pennsylvania Avenue",
+				"number": "1600"
+			}
+		},
+		"private_metadata": {
+			app_id: 5
+		},
 	}`

--- a/tests/integration/clerk_test.go
+++ b/tests/integration/clerk_test.go
@@ -10,18 +10,20 @@ import (
 type key string
 
 const (
+	APIUrl       = "CLERK_API_URL"
 	APIKey       = "CLERK_API_KEY"
 	SessionToken = "CLERK_SESSION_TOKEN"
 	SessionID    = "CLERK_SESSION_ID"
 )
 
 func createClient() clerk.Client {
+	apiUrl := getEnv(APIUrl)
 	apiKey := getEnv(APIKey)
-	return createClientWithKey(apiKey)
+	return createClientWithKey(apiUrl, apiKey)
 }
 
-func createClientWithKey(apiKey string) clerk.Client {
-	client, err := clerk.NewClient(apiKey)
+func createClientWithKey(apiUrl string, apiKey string) clerk.Client {
+	client, err := clerk.NewClientWithBaseUrl(apiKey, apiUrl)
 	if err != nil {
 		panic("Unable to create Clerk client")
 	}

--- a/tests/integration/users_test.go
+++ b/tests/integration/users_test.go
@@ -7,6 +7,19 @@ import (
 	"testing"
 )
 
+type addressDetails struct {
+	Street string `json:"street"`
+	Number string `json:"number"`
+}
+
+type userAddress struct {
+	Address addressDetails `json:"address"`
+}
+
+type userAppID struct {
+	AppID int `json:"app_id"`
+}
+
 func TestUsers(t *testing.T) {
 	client := createClient()
 
@@ -18,7 +31,7 @@ func TestUsers(t *testing.T) {
 		t.Fatalf("Users.ListAll returned nil")
 	}
 
-	for _, user := range users {
+	for i, user := range users {
 		userId := user.ID
 		user, err := client.Users().Read(userId)
 		if err != nil {
@@ -31,6 +44,11 @@ func TestUsers(t *testing.T) {
 		updateRequest := clerk.UpdateUser{
 			FirstName: user.FirstName,
 			LastName:  user.LastName,
+			PublicMetadata: userAddress{Address: addressDetails{
+				Street: "Fifth Avenue",
+				Number: "890",
+			}},
+			PrivateMetadata: userAppID{AppID: i},
 		}
 		updatedUser, err := client.Users().Update(userId, &updateRequest)
 		if err != nil {

--- a/tests/integration/verification_test.go
+++ b/tests/integration/verification_test.go
@@ -41,7 +41,7 @@ func TestVerification_verifySessionId(t *testing.T) {
 }
 
 func TestVerification_returnsClerkErrorForInvalidSessionID(t *testing.T) {
-	client := createClientWithKey("invalid_key")
+	client := createClientWithKey(getEnv(APIUrl), "invalid_key")
 
 	request := buildRequest(nil)
 


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

When updating a user, you can optionally define public and private metadata.
This metadata are JSON objects of any form and will be stored and returned along with the user itself.

### Related Issue (optional)

https://www.notion.so/clerkdev/User-custom-attributes-29dc3bba4d9442849c9831a09089042c
