### PR TITLE
Simplify session verification process using the new session verify endpoint

### DIFF
--- a/clerk/clients.go
+++ b/clerk/clients.go
@@ -36,13 +36,3 @@ func (s *ClientsService) Read(clientId string) (*ClientResponse, error) {
 	}
 	return &clientResponse, nil
 }
-
-func (s *ClientsService) Verify(token string) (*ClientResponse, error) {
-	var clientResponse ClientResponse
-
-	err := doVerify(s.client, ClientsVerifyUrl, token, &clientResponse)
-	if err != nil {
-		return nil, err
-	}
-	return &clientResponse, nil
-}

--- a/clerk/clients_test.go
+++ b/clerk/clients_test.go
@@ -80,41 +80,6 @@ func TestClientsService_Read_invalidServer(t *testing.T) {
 	}
 }
 
-func TestClientsService_Verify_happyPath(t *testing.T) {
-	token := "token"
-	sessionToken := "sessionToken"
-	expectedResponse := dummyClientResponseJson
-
-	client, mux, _, teardown := setup(token)
-	defer teardown()
-
-	mux.HandleFunc("/clients/verify", func(w http.ResponseWriter, req *http.Request) {
-		testHttpMethod(t, req, "POST")
-		testHeader(t, req, "Authorization", "Bearer "+token)
-		fmt.Fprint(w, expectedResponse)
-	})
-
-	var want ClientResponse
-	_ = json.Unmarshal([]byte(expectedResponse), &want)
-
-	got, _ := client.Clients().Verify(sessionToken)
-	if !reflect.DeepEqual(*got, want) {
-		t.Errorf("Response = %v, want %v", *got, want)
-	}
-}
-
-func TestClientsService_Verify_invalidServer(t *testing.T) {
-	client, _ := NewClient("token")
-
-	response, err := client.Clients().Verify("someSessionToken")
-	if err == nil {
-		t.Errorf("Expected error to be returned")
-	}
-	if response != nil {
-		t.Errorf("Was not expecting any client to be returned, instead got %v", response)
-	}
-}
-
 const dummyClientResponseJson = `{
         "ended": false,
         "id": "client_1mvnkzXhKhn9pDjp1f4x1id6pQZ",

--- a/clerk/sessions.go
+++ b/clerk/sessions.go
@@ -51,7 +51,18 @@ func (s *SessionsService) Revoke(sessionId string) (*Session, error) {
 	return &session, nil
 }
 
-func (s *SessionsService) Verify(sessionId string, token string) (*Session, error) {
+func (s *SessionsService) Verify(token string) (*Session, error) {
+	verifyUrl := fmt.Sprintf("%s/verify", SessionsUrl)
+	var sessionResponse Session
+
+	err := doVerify(s.client, verifyUrl, token, &sessionResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &sessionResponse, nil
+}
+
+func (s *SessionsService) VerifySession(sessionId string, token string) (*Session, error) {
 	verifyUrl := fmt.Sprintf("%s/%s/verify", SessionsUrl, sessionId)
 	var sessionResponse Session
 

--- a/clerk/verification.go
+++ b/clerk/verification.go
@@ -29,23 +29,10 @@ func (s *VerificationService) Verify(req *http.Request) (*Session, error) {
 	sessionId := req.URL.Query().Get(QueryParamSessionId)
 
 	if sessionId == "" {
-		return s.useClientActiveSession(sessionToken)
+		return s.client.Sessions().Verify(sessionToken)
 	}
 
-	return s.client.Sessions().Verify(sessionId, sessionToken)
-}
-
-func (s *VerificationService) useClientActiveSession(token string) (*Session, error) {
-	clientResponse, err := s.client.Clients().Verify(token)
-	if err != nil {
-		return nil, err
-	}
-
-	if clientResponse.LastActiveSessionID == nil {
-		return nil, errors.New("no active sessions for given client")
-	}
-
-	return s.client.Sessions().Read(*clientResponse.LastActiveSessionID)
+	return s.client.Sessions().VerifySession(sessionId, sessionToken)
 }
 
 func doVerify(client Client, url string, token string, response interface{}) error {

--- a/clerk/verification_test.go
+++ b/clerk/verification_test.go
@@ -72,14 +72,8 @@ func TestVerificationService_Verify_useClientActiveSession(t *testing.T) {
 
 	sessionJson := dummySessionJson
 
-	mux.HandleFunc("/clients/verify", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/sessions/verify", func(w http.ResponseWriter, req *http.Request) {
 		testHttpMethod(t, req, "POST")
-		testHeader(t, req, "Authorization", "Bearer "+apiToken)
-		fmt.Fprint(w, clientResponseJson)
-	})
-
-	mux.HandleFunc("/sessions/"+*clientResponse.LastActiveSessionID, func(w http.ResponseWriter, req *http.Request) {
-		testHttpMethod(t, req, "GET")
 		testHeader(t, req, "Authorization", "Bearer "+apiToken)
 		fmt.Fprint(w, sessionJson)
 	})
@@ -104,33 +98,9 @@ func TestVerificationService_Verify_handleServerErrorWhenUsingClientActiveSessio
 	client, mux, _, teardown := setup("apiToken")
 	defer teardown()
 
-	mux.HandleFunc("/clients/verify", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/sessions/verify", func(w http.ResponseWriter, req *http.Request) {
 		testHttpMethod(t, req, "POST")
 		w.WriteHeader(400)
-	})
-
-	_, err := client.Verification().Verify(request)
-	if err == nil {
-		t.Errorf("Was expecting error to be returned")
-	}
-}
-
-func TestVerificationService_Verify_noActiveSessionWhenUsingClientActiveSession(t *testing.T) {
-	apiToken := "apiToken"
-	sessionToken := "someSessionToken"
-	request := setupRequest(nil, &sessionToken)
-
-	client, mux, _, teardown := setup(apiToken)
-	defer teardown()
-
-	var clientResponse ClientResponse
-	_ = json.Unmarshal([]byte(dummyClientResponseJson), &clientResponse)
-	clientResponse.LastActiveSessionID = nil
-
-	mux.HandleFunc("/clients/verify", func(w http.ResponseWriter, req *http.Request) {
-		testHttpMethod(t, req, "POST")
-		jsonResp, _ := json.Marshal(clientResponse)
-		fmt.Fprint(w, string(jsonResp))
 	})
 
 	_, err := client.Verification().Verify(request)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Using the new sessions verify endpoint in SDK.

### Related Issue (optional)

https://www.notion.so/clerkdev/In-single-session-mode-without-_clerk_session_id-come-up-with-strategy-to-use-1-api-request-or-0--ab0fac16668c4dd487f668bd30077e4d
