### PR TITLE
If no session id is given, get the latest active from client's sessions

### DIFF
--- a/clerk/clients.go
+++ b/clerk/clients.go
@@ -5,12 +5,14 @@ import "fmt"
 type ClientsService service
 
 type ClientResponse struct {
-	Object              string  `json:"object"`
-	ID                  string  `json:"id"`
-	LastActiveSessionID *string `json:"last_active_session_id"`
-	SignInAttemptID     *string `json:"sign_in_attempt_id"`
-	SignUpAttemptID     *string `json:"sign_up_attempt_id"`
-	Ended               bool    `json:"ended"`
+	Object              string     `json:"object"`
+	ID                  string     `json:"id"`
+	LastActiveSessionID *string    `json:"last_active_session_id"`
+	SessionIDs          []string   `json:"session_ids"`
+	Sessions            []*Session `json:"sessions"`
+	SignInAttemptID     *string    `json:"sign_in_attempt_id"`
+	SignUpAttemptID     *string    `json:"sign_up_attempt_id"`
+	Ended               bool       `json:"ended"`
 }
 
 func (s *ClientsService) ListAll() ([]ClientResponse, error) {

--- a/clerk/clients_test.go
+++ b/clerk/clients_test.go
@@ -118,7 +118,18 @@ func TestClientsService_Verify_invalidServer(t *testing.T) {
 const dummyClientResponseJson = `{
         "ended": false,
         "id": "client_1mvnkzXhKhn9pDjp1f4x1id6pQZ",
-        "last_active_session_id": "sess_1mvnlhBAwUv8EktIKbooqqYwsUW",
+        "last_active_session_id": "sess_1mebQdHlQI14cjxln4e2eXNzwzi",
+		"session_ids": ["sess_1mebQdHlQI14cjxln4e2eXNzwzi"],
+        "sessions": [{
+			"id": "sess_1mebQdHlQI14cjxln4e2eXNzwzi",
+			"abandon_at": 1612448988,
+			"client_id": "client_1mebPYz8NFNA17fi7NemNXIwp1p",
+			"expire_at": 1610461788,
+			"last_active_at": 1609857251,
+			"object": "session",
+			"status": "ended",
+			"user_id": "user_1mebQggrD3xO5JfuHk7clQ94ysA"
+		}],
         "object": "client",
         "sign_in_attempt_id": null,
         "sign_up_attempt_id": null

--- a/clerk/verification.go
+++ b/clerk/verification.go
@@ -45,7 +45,13 @@ func (s *VerificationService) useClientActiveSession(token string) (*Session, er
 		return nil, errors.New("no active sessions for given client")
 	}
 
-	return s.client.Sessions().Read(*clientResponse.LastActiveSessionID)
+	for _, session := range clientResponse.Sessions {
+		if session.ID == *clientResponse.LastActiveSessionID {
+			return session, nil
+		}
+	}
+
+	return nil, errors.New("active session not included in client's sessions")
 }
 
 func doVerify(client Client, url string, token string, response interface{}) error {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Given that most applications will be single-session, we had to simplify the verification process for cases where we were not given a session id.

We modified the response of `/clients/verify` endpoint to return the list of sessions along with the client.
So, we don't need to have an additional call to the backend API anymore to get active session for the client, we can just get it from the returned sessions.

### Related Issue (optional)

https://www.notion.so/clerkdev/In-single-session-mode-without-_clerk_session_id-come-up-with-strategy-to-use-1-api-request-or-0--ab0fac16668c4dd487f668bd30077e4d
