### PR TITLE
Added Webhook operations in SDK

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -19,6 +19,7 @@ const (
 	SessionsUrl      = "sessions"
 	SMSUrl           = "sms_messages"
 	UsersUrl         = "users"
+	WebhooksUrl      = "webhooks"
 )
 
 type Client interface {
@@ -30,6 +31,7 @@ type Client interface {
 	Sessions() *SessionsService
 	SMS() *SMSService
 	Users() *UsersService
+	Webhooks() *WebhooksService
 	Verification() *VerificationService
 }
 
@@ -47,6 +49,7 @@ type client struct {
 	sessions     *SessionsService
 	sms          *SMSService
 	users        *UsersService
+	webhooks     *WebhooksService
 	verification *VerificationService
 }
 
@@ -73,6 +76,7 @@ func NewClientWithCustomHTTP(token string, urlStr string, httpClient *http.Clien
 	client.sessions = (*SessionsService)(commonService)
 	client.sms = (*SMSService)(commonService)
 	client.users = (*UsersService)(commonService)
+	client.webhooks = (*WebhooksService)(commonService)
 	client.verification = (*VerificationService)(commonService)
 
 	return client, nil
@@ -180,6 +184,10 @@ func (c *client) SMS() *SMSService {
 
 func (c *client) Users() *UsersService {
 	return c.users
+}
+
+func (c *client) Webhooks() *WebhooksService {
+	return c.webhooks
 }
 
 func (c *client) Verification() *VerificationService {

--- a/clerk/webhooks.go
+++ b/clerk/webhooks.go
@@ -1,0 +1,38 @@
+package clerk
+
+type WebhooksService service
+
+type DiahookResponse struct {
+	DiahookURL string `json:"diahook_url"`
+}
+
+func (s *WebhooksService) CreateDiahook() (*DiahookResponse, error) {
+	diahookUrl := WebhooksUrl + "/diahook"
+	req, _ := s.client.NewRequest("POST", diahookUrl)
+
+	var diahookResponse DiahookResponse
+	if _, err := s.client.Do(req, &diahookResponse); err != nil {
+		return nil, err
+	}
+	return &diahookResponse, nil
+}
+
+func (s *WebhooksService) DeleteDiahook() error {
+	diahookUrl := WebhooksUrl + "/diahook"
+	req, _ := s.client.NewRequest("DELETE", diahookUrl)
+
+	_, err := s.client.Do(req, nil)
+
+	return err
+}
+
+func (s *WebhooksService) RefreshDiahookURL() (*DiahookResponse, error) {
+	diahookUrl := WebhooksUrl + "/diahook_url"
+	req, _ := s.client.NewRequest("POST", diahookUrl)
+
+	var diahookResponse DiahookResponse
+	if _, err := s.client.Do(req, &diahookResponse); err != nil {
+		return nil, err
+	}
+	return &diahookResponse, nil
+}

--- a/clerk/webhooks_test.go
+++ b/clerk/webhooks_test.go
@@ -1,0 +1,104 @@
+package clerk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestWebhooksService_CreateDiahook_happyPath(t *testing.T) {
+	client, mux, _, teardown := setup("token")
+	defer teardown()
+
+	expectedResponse := dummyDiahookResponseJson
+
+	mux.HandleFunc("/webhooks/diahook", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, "POST")
+		testHeader(t, req, "Authorization", "Bearer token")
+		fmt.Fprint(w, expectedResponse)
+	})
+
+	var want DiahookResponse
+	_ = json.Unmarshal([]byte(expectedResponse), &want)
+
+	got, _ := client.Webhooks().CreateDiahook()
+	if !reflect.DeepEqual(*got, want) {
+		t.Errorf("response = %v, want %v", got, want)
+	}
+}
+
+func TestWebhooksService_CreateDiahook_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	diahookResponse, err := client.Webhooks().CreateDiahook()
+	if err == nil {
+		t.Errorf("expected error to be returned")
+	}
+	if diahookResponse != nil {
+		t.Errorf("was not expecting any users to be returned, instead got %v", diahookResponse)
+	}
+}
+
+func TestWebhooksService_DeleteDiahook_happyPath(t *testing.T) {
+	client, mux, _, teardown := setup("token")
+	defer teardown()
+
+	mux.HandleFunc("/webhooks/diahook", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, "DELETE")
+		testHeader(t, req, "Authorization", "Bearer token")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := client.Webhooks().DeleteDiahook()
+	if err != nil {
+		t.Errorf("was not expecting error, found %v instead", err)
+	}
+}
+
+func TestWebhooksService_DeleteDiahook_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	err := client.Webhooks().DeleteDiahook()
+	if err == nil {
+		t.Errorf("expected error to be returned")
+	}
+}
+
+func TestWebhooksService_RefreshDiahookURL_happyPath(t *testing.T) {
+	client, mux, _, teardown := setup("token")
+	defer teardown()
+
+	expectedResponse := dummyDiahookResponseJson
+
+	mux.HandleFunc("/webhooks/diahook_url", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, "POST")
+		testHeader(t, req, "Authorization", "Bearer token")
+		fmt.Fprint(w, expectedResponse)
+	})
+
+	var want DiahookResponse
+	_ = json.Unmarshal([]byte(expectedResponse), &want)
+
+	got, _ := client.Webhooks().RefreshDiahookURL()
+	if !reflect.DeepEqual(*got, want) {
+		t.Errorf("response = %v, want %v", got, want)
+	}
+}
+
+func TestWebhooksService_RefreshDiahookURL_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	diahookResponse, err := client.Webhooks().RefreshDiahookURL()
+	if err == nil {
+		t.Errorf("expected error to be returned")
+	}
+	if diahookResponse != nil {
+		t.Errorf("was not expecting any users to be returned, instead got %v", diahookResponse)
+	}
+}
+
+const dummyDiahookResponseJson = `{
+	"diahook_url": "http://example.diahook.com"
+}`

--- a/tests/integration/webhooks_test.go
+++ b/tests/integration/webhooks_test.go
@@ -1,0 +1,48 @@
+// +build integration
+
+package integration
+
+import (
+	"errors"
+	"github.com/clerkinc/clerk-sdk-go/clerk"
+	"testing"
+)
+
+func TestWebhooks(t *testing.T) {
+	client := createClient()
+
+	diahookResponse, err := client.Webhooks().CreateDiahook()
+	if err != nil {
+		checkIfCanRecoverFromDiahookCreation(t, err)
+	} else if diahookResponse.DiahookURL == "" {
+		t.Fatalf("Webhooks.CreateDiahook returned empty url")
+	}
+
+	diahookResponse, err = client.Webhooks().RefreshDiahookURL()
+	if err != nil {
+		t.Fatalf("Webhooks.RefreshDiahookURL returned unexpected unexpected error %v", err)
+	} else if diahookResponse.DiahookURL == "" {
+		t.Fatalf("was expecting a Diahook url, found none instead")
+	}
+
+	err = client.Webhooks().DeleteDiahook()
+	if err != nil {
+		t.Fatalf("Webhooks.DeleteDiahook returned unexpected error %v", err)
+	}
+}
+
+// checkIfCanRecoverFromDiahookCreation checks whether the error from creating
+// a new Diahook app was that there was already a Diahook for the given instance.
+// If it was, then we can continue, otherwise we fail.
+func checkIfCanRecoverFromDiahookCreation(t *testing.T, err error) {
+	var errorResponse *clerk.ErrorResponse
+	if !errors.As(err, &errorResponse) {
+		t.Fatalf("unexpected error found while creating diahook: %v", err)
+	}
+	if len(errorResponse.Errors) != 1 {
+		t.Fatalf("was only expecting at most one error, found %d instead: %v", len(errorResponse.Errors), errorResponse.Errors)
+	}
+	if errorResponse.Errors[0].Code != "diahook_app_exists" {
+		t.Fatalf("was expecting a diahook_app_exists error, found %s instead", errorResponse.Errors[0].Code)
+	}
+}


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This PR adds the webhook operations in the Go SDK.
In particular, it adds the following:
* CreateDiahook: Used to create a new Diahook app for the given instance
* RefreshDiahookURL: Returns a new url that can be used to access the Diahook management UI for the given app
* DeleteDiahook: Deletes the Diahook app associated with the given instance

### Related Issue (optional)

https://www.notion.so/clerkdev/Manage-webhooks-through-the-Dashboard-f744586818814b45828d09f8b6d09701
