### PR TITLE
chore: Rename Diahook to Svix

### DIFF
--- a/clerk/webhooks.go
+++ b/clerk/webhooks.go
@@ -2,37 +2,37 @@ package clerk
 
 type WebhooksService service
 
-type DiahookResponse struct {
-	DiahookURL string `json:"diahook_url"`
+type SvixResponse struct {
+	SvixURL string `json:"svix_url"`
 }
 
-func (s *WebhooksService) CreateDiahook() (*DiahookResponse, error) {
-	diahookUrl := WebhooksUrl + "/diahook"
-	req, _ := s.client.NewRequest("POST", diahookUrl)
+func (s *WebhooksService) CreateSvix() (*SvixResponse, error) {
+	svixUrl := WebhooksUrl + "/svix"
+	req, _ := s.client.NewRequest("POST", svixUrl)
 
-	var diahookResponse DiahookResponse
-	if _, err := s.client.Do(req, &diahookResponse); err != nil {
+	var svixResponse SvixResponse
+	if _, err := s.client.Do(req, &svixResponse); err != nil {
 		return nil, err
 	}
-	return &diahookResponse, nil
+	return &svixResponse, nil
 }
 
-func (s *WebhooksService) DeleteDiahook() error {
-	diahookUrl := WebhooksUrl + "/diahook"
-	req, _ := s.client.NewRequest("DELETE", diahookUrl)
+func (s *WebhooksService) DeleteSvix() error {
+	svixUrl := WebhooksUrl + "/svix"
+	req, _ := s.client.NewRequest("DELETE", svixUrl)
 
 	_, err := s.client.Do(req, nil)
 
 	return err
 }
 
-func (s *WebhooksService) RefreshDiahookURL() (*DiahookResponse, error) {
-	diahookUrl := WebhooksUrl + "/diahook_url"
-	req, _ := s.client.NewRequest("POST", diahookUrl)
+func (s *WebhooksService) RefreshSvixURL() (*SvixResponse, error) {
+	svixUrl := WebhooksUrl + "/svix_url"
+	req, _ := s.client.NewRequest("POST", svixUrl)
 
-	var diahookResponse DiahookResponse
-	if _, err := s.client.Do(req, &diahookResponse); err != nil {
+	var svixResponse SvixResponse
+	if _, err := s.client.Do(req, &svixResponse); err != nil {
 		return nil, err
 	}
-	return &diahookResponse, nil
+	return &svixResponse, nil
 }

--- a/clerk/webhooks_test.go
+++ b/clerk/webhooks_test.go
@@ -8,97 +8,97 @@ import (
 	"testing"
 )
 
-func TestWebhooksService_CreateDiahook_happyPath(t *testing.T) {
+func TestWebhooksService_CreateSvix_happyPath(t *testing.T) {
 	client, mux, _, teardown := setup("token")
 	defer teardown()
 
-	expectedResponse := dummyDiahookResponseJson
+	expectedResponse := dummySvixResponseJson
 
-	mux.HandleFunc("/webhooks/diahook", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/webhooks/svix", func(w http.ResponseWriter, req *http.Request) {
 		testHttpMethod(t, req, "POST")
 		testHeader(t, req, "Authorization", "Bearer token")
 		fmt.Fprint(w, expectedResponse)
 	})
 
-	var want DiahookResponse
+	var want SvixResponse
 	_ = json.Unmarshal([]byte(expectedResponse), &want)
 
-	got, _ := client.Webhooks().CreateDiahook()
+	got, _ := client.Webhooks().CreateSvix()
 	if !reflect.DeepEqual(*got, want) {
 		t.Errorf("response = %v, want %v", got, want)
 	}
 }
 
-func TestWebhooksService_CreateDiahook_invalidServer(t *testing.T) {
+func TestWebhooksService_CreateSvix_invalidServer(t *testing.T) {
 	client, _ := NewClient("token")
 
-	diahookResponse, err := client.Webhooks().CreateDiahook()
+	svixResponse, err := client.Webhooks().CreateSvix()
 	if err == nil {
 		t.Errorf("expected error to be returned")
 	}
-	if diahookResponse != nil {
-		t.Errorf("was not expecting any users to be returned, instead got %v", diahookResponse)
+	if svixResponse != nil {
+		t.Errorf("was not expecting any users to be returned, instead got %v", svixResponse)
 	}
 }
 
-func TestWebhooksService_DeleteDiahook_happyPath(t *testing.T) {
+func TestWebhooksService_DeleteSvix_happyPath(t *testing.T) {
 	client, mux, _, teardown := setup("token")
 	defer teardown()
 
-	mux.HandleFunc("/webhooks/diahook", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/webhooks/svix", func(w http.ResponseWriter, req *http.Request) {
 		testHttpMethod(t, req, "DELETE")
 		testHeader(t, req, "Authorization", "Bearer token")
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := client.Webhooks().DeleteDiahook()
+	err := client.Webhooks().DeleteSvix()
 	if err != nil {
 		t.Errorf("was not expecting error, found %v instead", err)
 	}
 }
 
-func TestWebhooksService_DeleteDiahook_invalidServer(t *testing.T) {
+func TestWebhooksService_DeleteSvix_invalidServer(t *testing.T) {
 	client, _ := NewClient("token")
 
-	err := client.Webhooks().DeleteDiahook()
+	err := client.Webhooks().DeleteSvix()
 	if err == nil {
 		t.Errorf("expected error to be returned")
 	}
 }
 
-func TestWebhooksService_RefreshDiahookURL_happyPath(t *testing.T) {
+func TestWebhooksService_RefreshSvixURL_happyPath(t *testing.T) {
 	client, mux, _, teardown := setup("token")
 	defer teardown()
 
-	expectedResponse := dummyDiahookResponseJson
+	expectedResponse := dummySvixResponseJson
 
-	mux.HandleFunc("/webhooks/diahook_url", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/webhooks/svix_url", func(w http.ResponseWriter, req *http.Request) {
 		testHttpMethod(t, req, "POST")
 		testHeader(t, req, "Authorization", "Bearer token")
 		fmt.Fprint(w, expectedResponse)
 	})
 
-	var want DiahookResponse
+	var want SvixResponse
 	_ = json.Unmarshal([]byte(expectedResponse), &want)
 
-	got, _ := client.Webhooks().RefreshDiahookURL()
+	got, _ := client.Webhooks().RefreshSvixURL()
 	if !reflect.DeepEqual(*got, want) {
 		t.Errorf("response = %v, want %v", got, want)
 	}
 }
 
-func TestWebhooksService_RefreshDiahookURL_invalidServer(t *testing.T) {
+func TestWebhooksService_RefreshSvixURL_invalidServer(t *testing.T) {
 	client, _ := NewClient("token")
 
-	diahookResponse, err := client.Webhooks().RefreshDiahookURL()
+	svixResponse, err := client.Webhooks().RefreshSvixURL()
 	if err == nil {
 		t.Errorf("expected error to be returned")
 	}
-	if diahookResponse != nil {
-		t.Errorf("was not expecting any users to be returned, instead got %v", diahookResponse)
+	if svixResponse != nil {
+		t.Errorf("was not expecting any users to be returned, instead got %v", svixResponse)
 	}
 }
 
-const dummyDiahookResponseJson = `{
-	"diahook_url": "http://example.diahook.com"
+const dummySvixResponseJson = `{
+	"svix_url": "http://example.svix.com"
 }`


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [x] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Diahook rebranded to Svix.

This PR contains all the necessary changes to keep our codebase up to date.

### Related Issue (optional)

https://github.com/clerkinc/clerk_go/pull/565
