### PR TITLE
feat: Introduce middleware for networkless authentication

### DIFF
--- a/clerk/middleware.go
+++ b/clerk/middleware.go
@@ -2,11 +2,13 @@ package clerk
 
 import (
 	"context"
+	"errors"
 	"net/http"
 )
 
 const (
 	ActiveSession = iota
+	ActiveClaims
 )
 
 func WithSession(client Client) func(handler http.Handler) http.Handler {
@@ -29,4 +31,42 @@ func addSessionToContext(request *http.Request, session *Session) *http.Request 
 	ctx := request.Context()
 	updated := context.WithValue(ctx, ActiveSession, session)
 	return request.WithContext(updated)
+}
+
+func WithNetworkless(client Client) func(handler http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token, err := retrieveTokenFromRequest(r)
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(err.Error()))
+				return
+			}
+
+			claims, err := client.VerifyToken(token)
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(err.Error()))
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), ActiveClaims, claims)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func retrieveTokenFromRequest(r *http.Request) (string, error) {
+	token := r.Header.Get("Authorization")
+	if token != "" {
+		return token, nil
+	}
+
+	for _, cookie := range r.Cookies() {
+		if cookie.Name == "__session" {
+			return cookie.Value, nil
+		}
+	}
+
+	return "", errors.New("no token found in request header or cookie")
 }


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This PR introduces a new middleware `WithNetworkless()` for the upcoming networkless authentication that retrieves a JWT token from the `Authorization` header and tries to verify it. If successful adds the JWT claims in the request context so you can easily access them inside a handler

### Related Issue (optional)

<!--- Please link to the issue here: -->
