### PR TITLE
refactor: DecodeToken to be generic and VerifyToken to use new claims

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -26,8 +26,8 @@ type Client interface {
 	NewRequest(method string, url string, body ...interface{}) (*http.Request, error)
 	Do(req *http.Request, v interface{}) (*http.Response, error)
 
-	DecodeToken(token string) (*Claims, error)
-	VerifyToken(token string) (*Claims, error)
+	DecodeToken(token string) (*TokenClaims, error)
+	VerifyToken(token string) (*SessionClaims, error)
 
 	Clients() *ClientsService
 	Emails() *EmailService

--- a/clerk/tokens_test.go
+++ b/clerk/tokens_test.go
@@ -16,7 +16,15 @@ import (
 )
 
 var (
-	dummyClaims = Claims{
+	dummyTokenClaims = map[string]interface{}{
+		"iss":     "issuer",
+		"sub":     "subject",
+		"aud":     []string{"clerk"},
+		"name":    "name",
+		"picture": "picture",
+	}
+
+	dummyTokenClaimsExpected = TokenClaims{
 		Claims: jwt.Claims{
 			Issuer:   "issuer",
 			Subject:  "subject",
@@ -24,10 +32,21 @@ var (
 			Expiry:   nil,
 			IssuedAt: nil,
 		},
-		UserClaims: UserClaims{
-			Name:    "name",
-			Picture: "picture",
+		Extra: map[string]interface{}{
+			"name":    "name",
+			"picture": "picture",
 		},
+	}
+
+	dummySessionClaims = SessionClaims{
+		Claims: jwt.Claims{
+			Issuer:   "clerk.issuer",
+			Subject:  "subject",
+			Audience: nil,
+			Expiry:   nil,
+			IssuedAt: nil,
+		},
+		SessionID: "session_id",
 	}
 )
 
@@ -42,12 +61,12 @@ func TestClient_DecodeToken_EmptyToken(t *testing.T) {
 
 func TestClient_DecodeToken_Success(t *testing.T) {
 	c, _ := NewClient("token")
-	token, _ := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, _ := testGenerateTokenJWT(t, dummyTokenClaims, "kid")
 
 	got, _ := c.DecodeToken(token)
 
-	if !reflect.DeepEqual(got, &dummyClaims) {
-		t.Errorf("Expected %+v, but got %+v", dummyClaims, got)
+	if !reflect.DeepEqual(got, &dummyTokenClaimsExpected) {
+		t.Errorf("Expected %+v, but got %+v", &dummyTokenClaimsExpected, got)
 	}
 }
 
@@ -62,7 +81,7 @@ func TestClient_VerifyToken_EmptyToken(t *testing.T) {
 
 func TestClient_VerifyToken_MissingKID(t *testing.T) {
 	c, _ := NewClient("token")
-	token, _ := testGenerateTokenJWT(t, dummyClaims, "")
+	token, _ := testGenerateTokenJWT(t, dummySessionClaims, "")
 
 	_, err := c.VerifyToken(token)
 	if err == nil {
@@ -72,7 +91,7 @@ func TestClient_VerifyToken_MissingKID(t *testing.T) {
 
 func TestClient_VerifyToken_MismatchKID(t *testing.T) {
 	c, _ := NewClient("token")
-	token, pubKey := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, pubKey := testGenerateTokenJWT(t, dummySessionClaims, "kid")
 
 	client := c.(*client)
 	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS256, "invalid-kid"))
@@ -85,7 +104,7 @@ func TestClient_VerifyToken_MismatchKID(t *testing.T) {
 
 func TestClient_VerifyToken_MismatchAlgorithm(t *testing.T) {
 	c, _ := NewClient("token")
-	token, pubKey := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, pubKey := testGenerateTokenJWT(t, dummySessionClaims, "kid")
 
 	client := c.(*client)
 	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS512, "kid"))
@@ -98,7 +117,25 @@ func TestClient_VerifyToken_MismatchAlgorithm(t *testing.T) {
 
 func TestClient_VerifyToken_InvalidKey(t *testing.T) {
 	c, _ := NewClient("token")
-	token, _ := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, _ := testGenerateTokenJWT(t, dummySessionClaims, "kid")
+	privKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	client := c.(*client)
+	client.jwksCache.set(testBuildJWKS(t, privKey.Public(), jose.RS256, "kid"))
+
+	_, err := c.VerifyToken(token)
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
+func TestClient_VerifyToken_InvalidIssuer(t *testing.T) {
+	c, _ := NewClient("token")
+
+	claims := dummySessionClaims
+	claims.Issuer = "issuer"
+
+	token, _ := testGenerateTokenJWT(t, claims, "kid")
 	privKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 
 	client := c.(*client)
@@ -113,7 +150,7 @@ func TestClient_VerifyToken_InvalidKey(t *testing.T) {
 func TestClient_VerifyToken_ExpiredToken(t *testing.T) {
 	c, _ := NewClient("token")
 
-	expiredClaims := dummyClaims
+	expiredClaims := dummySessionClaims
 	expiredClaims.Expiry = jwt.NewNumericDate(time.Now().Add(time.Second * -1))
 	token, pubKey := testGenerateTokenJWT(t, expiredClaims, "kid")
 
@@ -128,14 +165,14 @@ func TestClient_VerifyToken_ExpiredToken(t *testing.T) {
 
 func TestClient_VerifyToken_Success(t *testing.T) {
 	c, _ := NewClient("token")
-	token, pubKey := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, pubKey := testGenerateTokenJWT(t, dummySessionClaims, "kid")
 
 	client := c.(*client)
 	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS256, "kid"))
 
 	got, _ := c.VerifyToken(token)
-	if !reflect.DeepEqual(got, &dummyClaims) {
-		t.Errorf("Expected %+v, but got %+v", dummyClaims, got)
+	if !reflect.DeepEqual(got, &dummySessionClaims) {
+		t.Errorf("Expected %+v, but got %+v", dummySessionClaims, got)
 	}
 }
 
@@ -143,7 +180,7 @@ func TestClient_VerifyToken_Success_ExpiredCache(t *testing.T) {
 	c, mux, _, teardown := setup("token")
 	defer teardown()
 
-	token, pubKey := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, pubKey := testGenerateTokenJWT(t, dummySessionClaims, "kid")
 
 	mux.HandleFunc("/jwks", func(w http.ResponseWriter, req *http.Request) {
 		testHttpMethod(t, req, "GET")
@@ -155,12 +192,12 @@ func TestClient_VerifyToken_Success_ExpiredCache(t *testing.T) {
 	client.jwksCache.expiresAt = time.Now().Add(time.Second * -5)
 
 	got, _ := c.VerifyToken(token)
-	if !reflect.DeepEqual(got, &dummyClaims) {
-		t.Errorf("Expected %+v, but got %+v", dummyClaims, got)
+	if !reflect.DeepEqual(got, &dummySessionClaims) {
+		t.Errorf("Expected %+v, but got %+v", dummySessionClaims, got)
 	}
 }
 
-func testGenerateTokenJWT(t *testing.T, claims Claims, kid string) (string, crypto.PublicKey) {
+func testGenerateTokenJWT(t *testing.T, claims interface{}, kid string) (string, crypto.PublicKey) {
 	t.Helper()
 
 	privKey, err := rsa.GenerateKey(rand.Reader, 2048)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [x] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This PR changes the `DecodeToken` utility to decode any jwt token and not only a specific. Also updated the claims that the session token will include accordingly within the `VerifyToken` utility

### Related Issue (optional)

<!--- Please link to the issue here: -->
