### PR TITLE
feat: Change middleware to also handle AuthV2

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -26,8 +26,8 @@ type Client interface {
 	NewRequest(method string, url string, body ...interface{}) (*http.Request, error)
 	Do(req *http.Request, v interface{}) (*http.Response, error)
 
-	DecodeToken(token string) (*Claims, error)
-	VerifyToken(token string) (*Claims, error)
+	DecodeToken(token string) (*TokenClaims, error)
+	VerifyToken(token string) (*SessionClaims, error)
 
 	Clients() *ClientsService
 	Emails() *EmailService

--- a/clerk/middleware.go
+++ b/clerk/middleware.go
@@ -3,30 +3,63 @@ package clerk
 import (
 	"context"
 	"net/http"
+	"strings"
 )
 
 const (
 	ActiveSession = iota
+	ActiveSessionClaims
 )
 
 func WithSession(client Client) func(handler http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-			session, err := client.Verification().Verify(request)
-			if err != nil {
-				writer.WriteHeader(400)
-				writer.Write([]byte(err.Error()))
-				return
-			}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if token, isAuthV2 := isAuthV2Request(r, client); isAuthV2 {
+				// Validate using session token
+				claims, err := client.VerifyToken(token)
+				if err != nil {
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = w.Write([]byte(err.Error()))
+					return
+				}
 
-			updatedRequest := addSessionToContext(request, session)
-			next.ServeHTTP(writer, updatedRequest)
+				ctx := context.WithValue(r.Context(), ActiveSessionClaims, claims)
+				next.ServeHTTP(w, r.WithContext(ctx))
+			} else {
+				// Validate using session verify request
+				session, err := client.Verification().Verify(r)
+				if err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = w.Write([]byte(err.Error()))
+					return
+				}
+
+				ctx := context.WithValue(r.Context(), ActiveSession, session)
+				next.ServeHTTP(w, r.WithContext(ctx))
+			}
 		})
 	}
 }
 
-func addSessionToContext(request *http.Request, session *Session) *http.Request {
-	ctx := request.Context()
-	updated := context.WithValue(ctx, ActiveSession, session)
-	return request.WithContext(updated)
+func isAuthV2Request(r *http.Request, client Client) (string, bool) {
+	// Try with token from header
+	headerToken := r.Header.Get("Authorization")
+
+	claims, err := client.DecodeToken(headerToken)
+	if err == nil {
+		return headerToken, strings.HasPrefix(claims.Issuer, "https://clerk.")
+	}
+
+	// Verification from header token failed, try with token from cookie
+	cookieSession, err := r.Cookie(CookieSession)
+	if err != nil {
+		return "", false
+	}
+
+	claims, err = client.DecodeToken(cookieSession.Value)
+	if err != nil {
+		return "", false
+	}
+
+	return cookieSession.Value, strings.HasPrefix(claims.Issuer, "https://clerk.")
 }

--- a/clerk/middleware_test.go
+++ b/clerk/middleware_test.go
@@ -6,9 +6,14 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
+
+	"gopkg.in/square/go-jose.v2/jwt"
+
+	"gopkg.in/square/go-jose.v2"
 )
 
-func TestMiddleware_addSessionToContext(t *testing.T) {
+func TestWithSession_addSessionToContext(t *testing.T) {
 	apiToken := "apiToken"
 	sessionId := "someSessionId"
 	sessionToken := "someSessionToken"
@@ -46,7 +51,7 @@ func TestMiddleware_addSessionToContext(t *testing.T) {
 	}
 }
 
-func TestMiddleware_returnsErrorIfVerificationFails(t *testing.T) {
+func TestWithSession_returnsErrorIfVerificationFails(t *testing.T) {
 	apiToken := "apiToken"
 	sessionId := "someSessionId"
 	sessionToken := "someSessionToken"
@@ -72,7 +77,138 @@ func TestMiddleware_returnsErrorIfVerificationFails(t *testing.T) {
 
 	resp, _ := client.Do(request, nil)
 
-	if resp.StatusCode != 400 {
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Was expecting 400 error code, found %v instead", resp.StatusCode)
+	}
+}
+
+func TestWithSession_addSessionClaimsToContext_Header(t *testing.T) {
+	c, mux, serverUrl, teardown := setup("apiToken")
+	defer teardown()
+
+	expectedClaims := dummySessionClaims
+
+	token, pubKey := testGenerateTokenJWT(t, expectedClaims, "kid")
+
+	client := c.(*client)
+	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS256, "kid"))
+
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// this handler should be called after the middleware has added the `ActiveClaims`
+		claims := r.Context().Value(ActiveSessionClaims)
+		_ = json.NewEncoder(w).Encode(claims)
+	})
+
+	mux.Handle("/claims", WithSession(c)(dummyHandler))
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/claims", serverUrl), nil)
+	req.Header.Set("Authorization", token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer resp.Body.Close()
+
+	var got SessionClaims
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+
+	if !reflect.DeepEqual(got, expectedClaims) {
+		t.Errorf("Response = %v, want %v", got, expectedClaims)
+	}
+}
+
+func TestWithSession_addSessionClaimsToContext_Cookie(t *testing.T) {
+	c, mux, serverUrl, teardown := setup("apiToken")
+	defer teardown()
+
+	expectedClaims := dummySessionClaims
+
+	token, pubKey := testGenerateTokenJWT(t, expectedClaims, "kid")
+
+	client := c.(*client)
+	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS256, "kid"))
+
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// this handler should be called after the middleware has added the `ActiveClaims`
+		activeClaims := r.Context().Value(ActiveSessionClaims)
+		_ = json.NewEncoder(w).Encode(activeClaims)
+	})
+
+	mux.Handle("/claims", WithSession(c)(dummyHandler))
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/claims", serverUrl), nil)
+	req.AddCookie(&http.Cookie{
+		Name:     "__session",
+		Value:    token,
+		Secure:   true,
+		HttpOnly: true,
+	})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer resp.Body.Close()
+
+	var got SessionClaims
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+
+	if !reflect.DeepEqual(got, expectedClaims) {
+		t.Errorf("Response = %v, want %v", got, expectedClaims)
+	}
+}
+
+func TestWithSession_returnsErrorIfTokenVerificationFails(t *testing.T) {
+	c, mux, serverUrl, teardown := setup("apiToken")
+	defer teardown()
+
+	expectedClaims := dummySessionClaims
+	expectedClaims.Expiry = jwt.NewNumericDate(time.Now().Add(time.Second * -1))
+
+	token, pubKey := testGenerateTokenJWT(t, expectedClaims, "kid")
+
+	client := c.(*client)
+	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS256, "kid"))
+
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// this handler should be called after the middleware has added the `ActiveClaims`
+		activeClaims := r.Context().Value(ActiveSessionClaims)
+		_ = json.NewEncoder(w).Encode(activeClaims)
+	})
+
+	mux.Handle("/claims", WithSession(c)(dummyHandler))
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/claims", serverUrl), nil)
+	req.Header.Set("Authorization", token)
+
+	resp, _ := http.DefaultClient.Do(req)
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("Was expecting 401 error code, found %v instead", resp.StatusCode)
+	}
+}
+
+func TestWithSession_returnsErrorIfTokenMissing(t *testing.T) {
+	apiToken := "apiToken"
+
+	c, mux, serverUrl, teardown := setup(apiToken)
+	defer teardown()
+
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// this handler should be called after the middleware has added the `ActiveSession`
+		t.Errorf("This should never be called!")
+	})
+
+	mux.Handle("/claims", WithSession(c)(dummyHandler))
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/claims", serverUrl), nil)
+
+	resp, _ := http.DefaultClient.Do(req)
+
+	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("Was expecting 400 error code, found %v instead", resp.StatusCode)
 	}
 }

--- a/clerk/tokens.go
+++ b/clerk/tokens.go
@@ -80,8 +80,8 @@ func (c *client) VerifyToken(token string) (*SessionClaims, error) {
 		return nil, err
 	}
 
-	if !strings.HasPrefix(claims.Issuer, "clerk.") {
-		return nil, fmt.Errorf("invalid issuer format %s", claims.Issuer)
+	if !strings.HasPrefix(claims.Issuer, "https://clerk.") {
+		return nil, fmt.Errorf("invalid issuer %s", claims.Issuer)
 	}
 
 	return &claims, nil

--- a/clerk/tokens_test.go
+++ b/clerk/tokens_test.go
@@ -16,7 +16,15 @@ import (
 )
 
 var (
-	dummyClaims = Claims{
+	dummyTokenClaims = map[string]interface{}{
+		"iss":     "issuer",
+		"sub":     "subject",
+		"aud":     []string{"clerk"},
+		"name":    "name",
+		"picture": "picture",
+	}
+
+	dummyTokenClaimsExpected = TokenClaims{
 		Claims: jwt.Claims{
 			Issuer:   "issuer",
 			Subject:  "subject",
@@ -24,10 +32,21 @@ var (
 			Expiry:   nil,
 			IssuedAt: nil,
 		},
-		UserClaims: UserClaims{
-			Name:    "name",
-			Picture: "picture",
+		Extra: map[string]interface{}{
+			"name":    "name",
+			"picture": "picture",
 		},
+	}
+
+	dummySessionClaims = SessionClaims{
+		Claims: jwt.Claims{
+			Issuer:   "clerk.issuer",
+			Subject:  "subject",
+			Audience: nil,
+			Expiry:   nil,
+			IssuedAt: nil,
+		},
+		SessionID: "session_id",
 	}
 )
 
@@ -42,12 +61,12 @@ func TestClient_DecodeToken_EmptyToken(t *testing.T) {
 
 func TestClient_DecodeToken_Success(t *testing.T) {
 	c, _ := NewClient("token")
-	token, _ := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, _ := testGenerateTokenJWT(t, dummyTokenClaims, "kid")
 
 	got, _ := c.DecodeToken(token)
 
-	if !reflect.DeepEqual(got, &dummyClaims) {
-		t.Errorf("Expected %+v, but got %+v", dummyClaims, got)
+	if !reflect.DeepEqual(got, &dummyTokenClaimsExpected) {
+		t.Errorf("Expected %+v, but got %+v", &dummyTokenClaimsExpected, got)
 	}
 }
 
@@ -62,7 +81,7 @@ func TestClient_VerifyToken_EmptyToken(t *testing.T) {
 
 func TestClient_VerifyToken_MissingKID(t *testing.T) {
 	c, _ := NewClient("token")
-	token, _ := testGenerateTokenJWT(t, dummyClaims, "")
+	token, _ := testGenerateTokenJWT(t, dummySessionClaims, "")
 
 	_, err := c.VerifyToken(token)
 	if err == nil {
@@ -72,7 +91,7 @@ func TestClient_VerifyToken_MissingKID(t *testing.T) {
 
 func TestClient_VerifyToken_MismatchKID(t *testing.T) {
 	c, _ := NewClient("token")
-	token, pubKey := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, pubKey := testGenerateTokenJWT(t, dummySessionClaims, "kid")
 
 	client := c.(*client)
 	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS256, "invalid-kid"))
@@ -85,7 +104,7 @@ func TestClient_VerifyToken_MismatchKID(t *testing.T) {
 
 func TestClient_VerifyToken_MismatchAlgorithm(t *testing.T) {
 	c, _ := NewClient("token")
-	token, pubKey := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, pubKey := testGenerateTokenJWT(t, dummySessionClaims, "kid")
 
 	client := c.(*client)
 	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS512, "kid"))
@@ -98,7 +117,25 @@ func TestClient_VerifyToken_MismatchAlgorithm(t *testing.T) {
 
 func TestClient_VerifyToken_InvalidKey(t *testing.T) {
 	c, _ := NewClient("token")
-	token, _ := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, _ := testGenerateTokenJWT(t, dummySessionClaims, "kid")
+	privKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	client := c.(*client)
+	client.jwksCache.set(testBuildJWKS(t, privKey.Public(), jose.RS256, "kid"))
+
+	_, err := c.VerifyToken(token)
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
+func TestClient_VerifyToken_InvalidIssuer(t *testing.T) {
+	c, _ := NewClient("token")
+
+	claims := dummySessionClaims
+	claims.Issuer = "issuer"
+
+	token, _ := testGenerateTokenJWT(t, claims, "kid")
 	privKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 
 	client := c.(*client)
@@ -113,7 +150,7 @@ func TestClient_VerifyToken_InvalidKey(t *testing.T) {
 func TestClient_VerifyToken_ExpiredToken(t *testing.T) {
 	c, _ := NewClient("token")
 
-	expiredClaims := dummyClaims
+	expiredClaims := dummySessionClaims
 	expiredClaims.Expiry = jwt.NewNumericDate(time.Now().Add(time.Second * -1))
 	token, pubKey := testGenerateTokenJWT(t, expiredClaims, "kid")
 
@@ -128,14 +165,14 @@ func TestClient_VerifyToken_ExpiredToken(t *testing.T) {
 
 func TestClient_VerifyToken_Success(t *testing.T) {
 	c, _ := NewClient("token")
-	token, pubKey := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, pubKey := testGenerateTokenJWT(t, dummySessionClaims, "kid")
 
 	client := c.(*client)
 	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS256, "kid"))
 
 	got, _ := c.VerifyToken(token)
-	if !reflect.DeepEqual(got, &dummyClaims) {
-		t.Errorf("Expected %+v, but got %+v", dummyClaims, got)
+	if !reflect.DeepEqual(got, &dummySessionClaims) {
+		t.Errorf("Expected %+v, but got %+v", dummySessionClaims, got)
 	}
 }
 
@@ -143,7 +180,7 @@ func TestClient_VerifyToken_Success_ExpiredCache(t *testing.T) {
 	c, mux, _, teardown := setup("token")
 	defer teardown()
 
-	token, pubKey := testGenerateTokenJWT(t, dummyClaims, "kid")
+	token, pubKey := testGenerateTokenJWT(t, dummySessionClaims, "kid")
 
 	mux.HandleFunc("/jwks", func(w http.ResponseWriter, req *http.Request) {
 		testHttpMethod(t, req, "GET")
@@ -155,12 +192,12 @@ func TestClient_VerifyToken_Success_ExpiredCache(t *testing.T) {
 	client.jwksCache.expiresAt = time.Now().Add(time.Second * -5)
 
 	got, _ := c.VerifyToken(token)
-	if !reflect.DeepEqual(got, &dummyClaims) {
-		t.Errorf("Expected %+v, but got %+v", dummyClaims, got)
+	if !reflect.DeepEqual(got, &dummySessionClaims) {
+		t.Errorf("Expected %+v, but got %+v", dummySessionClaims, got)
 	}
 }
 
-func testGenerateTokenJWT(t *testing.T, claims Claims, kid string) (string, crypto.PublicKey) {
+func testGenerateTokenJWT(t *testing.T, claims interface{}, kid string) (string, crypto.PublicKey) {
 	t.Helper()
 
 	privKey, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/clerk/tokens_test.go
+++ b/clerk/tokens_test.go
@@ -40,7 +40,7 @@ var (
 
 	dummySessionClaims = SessionClaims{
 		Claims: jwt.Claims{
-			Issuer:   "clerk.issuer",
+			Issuer:   "https://clerk.issuer",
 			Subject:  "subject",
 			Audience: nil,
 			Expiry:   nil,
@@ -135,11 +135,10 @@ func TestClient_VerifyToken_InvalidIssuer(t *testing.T) {
 	claims := dummySessionClaims
 	claims.Issuer = "issuer"
 
-	token, _ := testGenerateTokenJWT(t, claims, "kid")
-	privKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	token, pubKey := testGenerateTokenJWT(t, claims, "kid")
 
 	client := c.(*client)
-	client.jwksCache.set(testBuildJWKS(t, privKey.Public(), jose.RS256, "kid"))
+	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS256, "kid"))
 
 	_, err := c.VerifyToken(token)
 	if err == nil {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This PR changes the current middleware `WithSession` to also handle session tokens that will be used in the upcoming networkless authentication. If successful adds the JWT claims in the request context so you can easily access them inside a handler. This change should not affect or change the middleware behavior for the current use cases

### Related Issue (optional)

<!--- Please link to the issue here: -->
