### PR TITLE
feat: Add support for template CRUD operations

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -18,6 +18,7 @@ const (
 	EmailsUrl        = "emails"
 	SessionsUrl      = "sessions"
 	SMSUrl           = "sms_messages"
+	TemplatesUrl     = "templates"
 	UsersUrl         = "users"
 	WebhooksUrl      = "webhooks"
 )
@@ -34,6 +35,7 @@ type Client interface {
 	JWKS() *JWKSService
 	Sessions() *SessionsService
 	SMS() *SMSService
+	Templates() *TemplatesService
 	Users() *UsersService
 	Webhooks() *WebhooksService
 	Verification() *VerificationService
@@ -57,6 +59,7 @@ type client struct {
 	jwks         *JWKSService
 	sessions     *SessionsService
 	sms          *SMSService
+	templates    *TemplatesService
 	users        *UsersService
 	webhooks     *WebhooksService
 	verification *VerificationService
@@ -85,6 +88,7 @@ func NewClientWithCustomHTTP(token string, urlStr string, httpClient *http.Clien
 	client.jwks = (*JWKSService)(commonService)
 	client.sessions = (*SessionsService)(commonService)
 	client.sms = (*SMSService)(commonService)
+	client.templates = (*TemplatesService)(commonService)
 	client.users = (*UsersService)(commonService)
 	client.webhooks = (*WebhooksService)(commonService)
 	client.verification = (*VerificationService)(commonService)
@@ -196,6 +200,10 @@ func (c *client) Sessions() *SessionsService {
 
 func (c *client) SMS() *SMSService {
 	return c.sms
+}
+
+func (c *client) Templates() *TemplatesService {
+	return c.templates
 }
 
 func (c *client) Users() *UsersService {

--- a/clerk/clerk_test.go
+++ b/clerk/clerk_test.go
@@ -149,7 +149,7 @@ func TestDo_sendsTokenInRequest(t *testing.T) {
 
 	mux.HandleFunc("/test", func(w http.ResponseWriter, req *http.Request) {
 		testHeader(t, req, "Authorization", "Bearer "+token)
-		w.WriteHeader(204)
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	req, _ := client.NewRequest("GET", "test")

--- a/clerk/delete_response.go
+++ b/clerk/delete_response.go
@@ -1,0 +1,8 @@
+package clerk
+
+type DeleteResponse struct {
+	ID      string `json:"id,omitempty"`
+	Slug    string `json:"slug,omitempty"`
+	Object  string `json:"object"`
+	Deleted bool   `json:"deleted"`
+}

--- a/clerk/templates.go
+++ b/clerk/templates.go
@@ -1,0 +1,102 @@
+package clerk
+
+import "fmt"
+
+type TemplatesService service
+
+type Template struct {
+	Object       string `json:"object"`
+	Slug         string `json:"slug"`
+	TemplateType string `json:"template_type"`
+	Name         string `json:"name"`
+	Position     int    `json:"position"`
+	CanRevert    bool   `json:"can_revert"`
+	CanDelete    bool   `json:"can_delete"`
+	CreatedAt    int64  `json:"created_at"`
+	UpdatedAt    int64  `json:"updated_at"`
+}
+
+type TemplateExtended struct {
+	*Template
+	Markup             string   `json:"markup"`
+	Body               string   `json:"body"`
+	MandatoryVariables []string `json:"mandatory_variables"`
+}
+
+func (s *TemplatesService) ListAll(templateType string) ([]Template, error) {
+	templateURL := fmt.Sprintf("%s/%s", TemplatesUrl, templateType)
+	req, _ := s.client.NewRequest("GET", templateURL)
+
+	var templates []Template
+
+	_, err := s.client.Do(req, &templates)
+	if err != nil {
+		return nil, err
+	}
+
+	return templates, nil
+}
+
+func (s *TemplatesService) Read(templateType, slug string) (*TemplateExtended, error) {
+	templateURL := fmt.Sprintf("%s/%s/%s", TemplatesUrl, templateType, slug)
+
+	req, _ := s.client.NewRequest("GET", templateURL)
+
+	var templateExtended TemplateExtended
+
+	_, err := s.client.Do(req, &templateExtended)
+	if err != nil {
+		return nil, err
+	}
+
+	return &templateExtended, nil
+}
+
+type UpsertTemplateRequest struct {
+	Name               string   `json:"name"`
+	Markup             string   `json:"markup,omitempty"`
+	Body               string   `json:"body"`
+	MandatoryVariables []string `json:"mandatory_variables,omitempty"`
+}
+
+func (s *TemplatesService) Upsert(templateType, slug string, upsertTemplateRequest *UpsertTemplateRequest) (*TemplateExtended, error) {
+	templateURL := fmt.Sprintf("%s/%s/%s", TemplatesUrl, templateType, slug)
+	req, _ := s.client.NewRequest("PUT", templateURL, upsertTemplateRequest)
+
+	var upsertedTemplate TemplateExtended
+
+	_, err := s.client.Do(req, &upsertedTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	return &upsertedTemplate, nil
+}
+
+// Revert reverts a user template to the corresponding system template
+func (s *TemplatesService) Revert(templateType, slug string) (*TemplateExtended, error) {
+	templateURL := fmt.Sprintf("%s/%s/%s/revert", TemplatesUrl, templateType, slug)
+	req, _ := s.client.NewRequest("POST", templateURL)
+
+	var templateExtended TemplateExtended
+
+	_, err := s.client.Do(req, &templateExtended)
+	if err != nil {
+		return nil, err
+	}
+
+	return &templateExtended, nil
+}
+
+// Delete deletes a custom user template
+func (s *TemplatesService) Delete(templateType, slug string) (*DeleteResponse, error) {
+	templateURL := fmt.Sprintf("%s/%s/%s", TemplatesUrl, templateType, slug)
+	req, _ := s.client.NewRequest("DELETE", templateURL)
+
+	var delResponse DeleteResponse
+	if _, err := s.client.Do(req, &delResponse); err != nil {
+		return nil, err
+	}
+
+	return &delResponse, nil
+}

--- a/clerk/templates_test.go
+++ b/clerk/templates_test.go
@@ -1,0 +1,182 @@
+package clerk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplatesService_List_All_happyPath(t *testing.T) {
+	client, mux, _, teardown := setup("token")
+	defer teardown()
+
+	templateType := "email"
+
+	expectedResponse := "[" + dummyTemplateJSON + "]"
+
+	url := fmt.Sprintf("/templates/%s", templateType)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, "GET")
+		testHeader(t, req, "Authorization", "Bearer token")
+		fmt.Fprint(w, expectedResponse)
+	})
+
+	var want []Template
+	_ = json.Unmarshal([]byte(expectedResponse), &want)
+
+	got, err := client.Templates().ListAll("email")
+	assert.Nil(t, err)
+
+	if len(got) != len(want) {
+		t.Errorf("Was expecting %d user to be returned, instead got %d", len(want), len(got))
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Response = %v, want %v", got, want)
+	}
+}
+
+func TestTemplatesService_Read_happyPath(t *testing.T) {
+	token := "token"
+	templateType := "email"
+	slug := "metalslug"
+	expectedResponse := dummyUserJson
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	url := fmt.Sprintf("/templates/%s/%s", templateType, slug)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, "GET")
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, expectedResponse)
+	})
+
+	var want TemplateExtended
+	_ = json.Unmarshal([]byte(expectedResponse), &want)
+
+	got, err := client.Templates().Read("email", slug)
+	assert.Nil(t, err)
+
+	if !reflect.DeepEqual(*got, want) {
+		t.Errorf("Response = %v, want %v", *got, want)
+	}
+}
+
+func TestTemplatesService_Upsert_happyPath(t *testing.T) {
+	token := "token"
+	templateType := "email"
+	slug := "metalslug"
+
+	var payload UpsertTemplateRequest
+	_ = json.Unmarshal([]byte(dummyUpsertRequestJSON), &payload)
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	url := fmt.Sprintf("/templates/%s/%s", templateType, slug)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, "PUT")
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, dummyTemplateJSON)
+	})
+
+	got, err := client.Templates().Upsert("email", slug, &payload)
+	assert.Nil(t, err)
+
+	var want TemplateExtended
+	_ = json.Unmarshal([]byte(dummyTemplateJSON), &want)
+
+	if !reflect.DeepEqual(*got, want) {
+		t.Errorf("Response = %v, want %v", *got, payload)
+	}
+}
+
+func TestTemplatesService_RevertToSystemTemplate_happyPath(t *testing.T) {
+	token := "token"
+	templateType := "email"
+	slug := "metalslug"
+	expectedResponse := dummyTemplateJSON
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	url := fmt.Sprintf("/templates/%s/%s/revert", templateType, slug)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, "POST")
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, expectedResponse)
+	})
+
+	var want TemplateExtended
+	_ = json.Unmarshal([]byte(expectedResponse), &want)
+
+	got, err := client.Templates().Revert("email", slug)
+	assert.Nil(t, err)
+
+	if !reflect.DeepEqual(*got, want) {
+		t.Errorf("Response = %v, want %v", *got, want)
+	}
+}
+
+func TestTemplatesService_Delete_happyPath(t *testing.T) {
+	token := "token"
+	templateType := "email"
+	slug := "metalslug"
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	url := fmt.Sprintf("/templates/%s/%s", templateType, slug)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, "DELETE")
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		response := fmt.Sprintf(`{ "deleted": true, "slug": "%v", "object": "template" }`, slug)
+		fmt.Fprint(w, response)
+	})
+
+	want := DeleteResponse{Slug: slug, Object: "template", Deleted: true}
+
+	got, err := client.Templates().Delete("email", slug)
+	assert.Nil(t, err)
+
+	if !reflect.DeepEqual(*got, want) {
+		t.Errorf("Response = %v, want %v", *got, want)
+	}
+}
+
+const dummyTemplateJSON = `{
+    "object": "template",
+    "slug": "derp",
+    "template_type": "email",
+    "name": "Vin Diesel",
+    "position": 0,
+    "created_at": 1633541368454,
+    "updated_at": 1633541368454,
+    "markup": "<p>Hee Hee</p>",
+    "body": "<p>Ho Ho</p>",
+    "mandatory_variables": [
+        "michael",
+        "jackson"
+    ]
+}`
+
+const dummyUpsertRequestJSON = `{
+	"template_type": "email",
+	"name": "Dominic Toretto",       
+	"markup": "<p>Family</p>"          
+	"body": "<p>One quarter of a mile at a time<p>"          
+	"mandatoryVariables": [
+		"nitro",
+		"turbo"
+	]
+}`

--- a/clerk/users.go
+++ b/clerk/users.go
@@ -100,12 +100,6 @@ func (s *UsersService) Read(userId string) (*User, error) {
 	return &user, nil
 }
 
-type DeleteResponse struct {
-	ID      string `json:"id"`
-	Object  string `json:"object"`
-	Deleted bool   `json:"deleted"`
-}
-
 func (s *UsersService) Delete(userId string) (*DeleteResponse, error) {
 	userUrl := fmt.Sprintf("%s/%s", UsersUrl, userId)
 	req, _ := s.client.NewRequest("DELETE", userUrl)

--- a/tests/integration/templates_test.go
+++ b/tests/integration/templates_test.go
@@ -1,0 +1,49 @@
+// +build integration
+
+package integration
+
+import (
+	"github.com/clerkinc/clerk-sdk-go/clerk"
+	"testing"
+)
+
+func TestTemplates(t *testing.T) {
+	client := createClient()
+
+	templateType := "email"
+
+	templates, err := client.Templates().ListAll(templateType)
+	if err != nil {
+		t.Fatalf("Templates.ListAll returned error: %v", err)
+	}
+	if templates == nil {
+		t.Fatalf("Templates.ListAll returned nil")
+	}
+
+	for _, template := range templates {
+		slug := template.Slug
+
+		tmpl, err := client.Templates().Read(templateType, slug)
+		if err != nil {
+			t.Fatalf("Templates.Read returned error: %v", err)
+		}
+		if tmpl == nil {
+			t.Fatalf("Templates.Read returned nil")
+		}
+
+		upsertTemplateRequest := clerk.UpsertTemplateRequest{
+			Name:               "Remarketing SMS",
+			Markup:             "",
+			Body:               "Click {link} for free unicorns",
+			MandatoryVariables: []string{"lorem", "ipsum"},
+		}
+
+		upsertedTemplate, err := client.Templates().Upsert(templateType, slug, &upsertTemplateRequest)
+		if err != nil {
+			t.Fatalf("Templates.Update returned error: %v", err)
+		}
+		if upsertedTemplate == nil {
+			t.Errorf("Templates.Upsert returned nil")
+		}
+	}
+}


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Adds support for the following (email & SMS) template CRUD operations:

![image](https://user-images.githubusercontent.com/5611795/136559694-5e037548-8349-4ce1-8c7a-df5353278359.png)

