### PR TITLE
fix: Add subject for email templates

### DIFF
--- a/clerk/templates.go
+++ b/clerk/templates.go
@@ -18,6 +18,7 @@ type Template struct {
 
 type TemplateExtended struct {
 	*Template
+	Subject            string   `json:"subject"`
 	Markup             string   `json:"markup"`
 	Body               string   `json:"body"`
 	MandatoryVariables []string `json:"mandatory_variables"`
@@ -54,6 +55,7 @@ func (s *TemplatesService) Read(templateType, slug string) (*TemplateExtended, e
 
 type UpsertTemplateRequest struct {
 	Name               string   `json:"name"`
+	Subject            string   `json:"subject,omitempty"`
 	Markup             string   `json:"markup,omitempty"`
 	Body               string   `json:"body"`
 	MandatoryVariables []string `json:"mandatory_variables,omitempty"`

--- a/clerk/templates_test.go
+++ b/clerk/templates_test.go
@@ -162,6 +162,7 @@ const dummyTemplateJSON = `{
     "position": 0,
     "created_at": 1633541368454,
     "updated_at": 1633541368454,
+	"subject": "Choo choo train",
     "markup": "<p>Hee Hee</p>",
     "body": "<p>Ho Ho</p>",
     "mandatory_variables": [
@@ -172,7 +173,8 @@ const dummyTemplateJSON = `{
 
 const dummyUpsertRequestJSON = `{
 	"template_type": "email",
-	"name": "Dominic Toretto",       
+	"name": "Dominic Toretto",
+	"subject": "NOS bottles for sale",
 	"markup": "<p>Family</p>"          
 	"body": "<p>One quarter of a mile at a time<p>"          
 	"mandatoryVariables": [

--- a/tests/integration/templates_test.go
+++ b/tests/integration/templates_test.go
@@ -33,6 +33,7 @@ func TestTemplates(t *testing.T) {
 
 		upsertTemplateRequest := clerk.UpsertTemplateRequest{
 			Name:               "Remarketing SMS",
+			Subject:            "Unmissable opportunity",
 			Markup:             "",
 			Body:               "Click {link} for free unicorns",
 			MandatoryVariables: []string{"lorem", "ipsum"},


### PR DESCRIPTION
## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Had omitted the `subject` field in my last commit.

