### PR TITLE
feat: Add support for template previews

### DIFF
--- a/clerk/templates.go
+++ b/clerk/templates.go
@@ -25,6 +25,11 @@ type TemplateExtended struct {
 	MandatoryVariables []string `json:"mandatory_variables"`
 }
 
+type TemplatePreview struct {
+	Subject string `json:"subject,omitempty"`
+	Body    string `json:"body"`
+}
+
 func (s *TemplatesService) ListAll(templateType string) ([]Template, error) {
 	templateURL := fmt.Sprintf("%s/%s", TemplatesUrl, templateType)
 	req, _ := s.client.NewRequest("GET", templateURL)
@@ -58,6 +63,11 @@ type UpsertTemplateRequest struct {
 	Name    string `json:"name"`
 	Subject string `json:"subject,omitempty"`
 	Markup  string `json:"markup,omitempty"`
+	Body    string `json:"body"`
+}
+
+type PreviewTemplateRequest struct {
+	Subject string `json:"subject,omitempty"`
 	Body    string `json:"body"`
 }
 
@@ -101,4 +111,19 @@ func (s *TemplatesService) Delete(templateType, slug string) (*DeleteResponse, e
 	}
 
 	return &delResponse, nil
+}
+
+// Preview returns a rendering of a template with sample data for preview purposes
+func (s *TemplatesService) Preview(templateType, slug string, previewTemplateRequest *PreviewTemplateRequest) (*TemplatePreview, error) {
+	templateURL := fmt.Sprintf("%s/%s/%s/preview", TemplatesUrl, templateType, slug)
+	req, _ := s.client.NewRequest("POST", templateURL, previewTemplateRequest)
+
+	var templatePreview TemplatePreview
+
+	_, err := s.client.Do(req, &templatePreview)
+	if err != nil {
+		return nil, err
+	}
+
+	return &templatePreview, nil
 }

--- a/tests/integration/templates_test.go
+++ b/tests/integration/templates_test.go
@@ -35,7 +35,7 @@ func TestTemplates(t *testing.T) {
 			Name:    "Remarketing SMS",
 			Subject: "Unmissable opportunity",
 			Markup:  "",
-			Body:    "Click {link} for free unicorns",
+			Body:    "Click {{link}} for free unicorns",
 		}
 
 		upsertedTemplate, err := client.Templates().Upsert(templateType, slug, &upsertTemplateRequest)
@@ -44,6 +44,19 @@ func TestTemplates(t *testing.T) {
 		}
 		if upsertedTemplate == nil {
 			t.Errorf("Templates.Upsert returned nil")
+		}
+
+		previewTemplateRequest := clerk.PreviewTemplateRequest{
+			Subject: "{{AppName}} is da bomb",
+			Body:    "<p><a href=\"{{AppURL}}\">{{AppName}}</a> is the greatest app of all time!</p>",
+		}
+
+		templatePreview, err := client.Templates().Preview(templateType, slug, &previewTemplateRequest)
+		if err != nil {
+			t.Fatalf("Templates.Preview returned error: %v", err)
+		}
+		if templatePreview == nil {
+			t.Errorf("Templates.Preview returned nil")
 		}
 	}
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [X] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Added support for the `POST /v1/templates/{template_type}/{slug}/preview` backend API endpoint.
