### PR TITLE
fix: Templates integration tests to include the required variables per slug

### DIFF
--- a/tests/integration/templates_test.go
+++ b/tests/integration/templates_test.go
@@ -3,8 +3,10 @@
 package integration
 
 import (
-	"github.com/clerkinc/clerk-sdk-go/clerk"
+	"fmt"
 	"testing"
+
+	"github.com/clerkinc/clerk-sdk-go/clerk"
 )
 
 func TestTemplates(t *testing.T) {
@@ -31,11 +33,23 @@ func TestTemplates(t *testing.T) {
 			t.Fatalf("Templates.Read returned nil")
 		}
 
+		var requiredVariable string
+		switch slug {
+		case "invitation":
+			requiredVariable = "{{ActionURL}}"
+		case "magic_link":
+			requiredVariable = "{{MagicLink}}"
+		case "suspicious_activity":
+			requiredVariable = "{{Reason}}"
+		case "verification_code":
+			requiredVariable = "{{OTPCode}}"
+		}
+
 		upsertTemplateRequest := clerk.UpsertTemplateRequest{
-			Name:    "Remarketing SMS",
+			Name:    "Remarketing email",
 			Subject: "Unmissable opportunity",
 			Markup:  "",
-			Body:    "Click {{link}} for free unicorns",
+			Body:    fmt.Sprintf("Click %s for free unicorns", requiredVariable),
 		}
 
 		upsertedTemplate, err := client.Templates().Upsert(templateType, slug, &upsertTemplateRequest)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

After the recent changes in the templates endpoint, we need to include the required variables for each template slug, otherwise the integration tests will fail, blocking any new PR

### Related Issue (optional)

<!--- Please link to the issue here: -->
