### PR TITLE
feat: Provide functional options for the client constructor

### DIFF
--- a/clerk/clerk_options.go
+++ b/clerk/clerk_options.go
@@ -1,0 +1,38 @@
+package clerk
+
+import (
+	"errors"
+	"net/http"
+)
+
+// ClerkOption describes a functional parameter for the clerk client constructor
+type ClerkOption func(*client) error
+
+// WithHTTPClient allows the overriding of the http client
+func WithHTTPClient(httpClient *http.Client) ClerkOption {
+	return func(c *client) error {
+		if httpClient == nil {
+			return errors.New("http client can't be nil")
+		}
+
+		c.client = httpClient
+		return nil
+	}
+}
+
+// WithBaseURL allows the overriding of the base URL
+func WithBaseURL(rawURL string) ClerkOption {
+	return func(c *client) error {
+		if rawURL == "" {
+			return errors.New("base url can't be empty")
+		}
+
+		baseURL, err := toURLWithEndingSlash(rawURL)
+		if err != nil {
+			return err
+		}
+
+		c.baseURL = baseURL
+		return nil
+	}
+}

--- a/clerk/clerk_options_test.go
+++ b/clerk/clerk_options_test.go
@@ -1,0 +1,56 @@
+package clerk
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestWithHTTPClient(t *testing.T) {
+	expectedHTTPClient := &http.Client{Timeout: time.Second * 10}
+
+	got, err := NewClient("token", WithHTTPClient(expectedHTTPClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.(*client).client != expectedHTTPClient {
+		t.Fatalf("Expected the http client to have been overriden")
+	}
+}
+
+func TestWithHTTPClientNil(t *testing.T) {
+	_, err := NewClient("token", WithHTTPClient(nil))
+	if err == nil {
+		t.Fatalf("Expected an error with a nil http client provided")
+	}
+}
+
+func TestWithBaseURL(t *testing.T) {
+	expectedBaseURL := "https://api.example.com/"
+
+	got, err := NewClient("token", WithBaseURL(expectedBaseURL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.(*client).baseURL.String() != expectedBaseURL {
+		t.Fatalf("Expected the base URL to have been overriden")
+	}
+}
+
+func TestWithBaseURLEmpty(t *testing.T) {
+	_, err := NewClient("token", WithBaseURL(""))
+	if err == nil {
+		t.Fatalf("Expected an error with an empty base URL provided")
+	}
+}
+
+func TestWithBaseURLInvalid(t *testing.T) {
+	invalidBaseURL := "https:// api.example.com"
+
+	_, err := NewClient("token", WithBaseURL(invalidBaseURL))
+	if err == nil {
+		t.Fatalf("Expected an error with an invalid base URL provided")
+	}
+}

--- a/clerk/clerk_test.go
+++ b/clerk/clerk_test.go
@@ -23,7 +23,7 @@ func TestNewClient_baseUrl(t *testing.T) {
 
 func TestNewClient_baseUrlWithoutSlash(t *testing.T) {
 	input, want := "http://host/v1", "http://host/v1/"
-	c, _ := NewClientWithBaseUrl("token", input)
+	c, _ := NewClient("token", WithBaseURL(input))
 
 	if got := c.(*client).baseURL.String(); got != want {
 		t.Errorf("NewClient BaseURL is %v, want %v", got, want)
@@ -31,10 +31,13 @@ func TestNewClient_baseUrlWithoutSlash(t *testing.T) {
 }
 
 func TestNewClient_createsDifferentClients(t *testing.T) {
+	httpClient1, httpClient2 := &http.Client{}, &http.Client{}
+
 	token := "token"
-	c, _ := NewClient(token)
-	c2, _ := NewClient(token)
-	if c.(*client).client == c2.(*client).client {
+	c1, _ := NewClient(token, WithHTTPClient(httpClient1))
+	c2, _ := NewClient(token, WithHTTPClient(httpClient2))
+
+	if c1.(*client).client == c2.(*client).client {
 		t.Error("NewClient returned same http.Clients, but they should differ")
 	}
 }
@@ -160,7 +163,7 @@ func TestDo_sendsTokenInRequest(t *testing.T) {
 }
 
 func TestDo_invalidServer(t *testing.T) {
-	client, _ := NewClientWithBaseUrl("token", "http://dummy_url:1337")
+	client, _ := NewClient("token", WithBaseURL("http://dummy_url:1337"))
 
 	req, _ := client.NewRequest("GET", "test")
 

--- a/clerk/http_utils_test.go
+++ b/clerk/http_utils_test.go
@@ -20,7 +20,7 @@ func setup(token string) (client Client, mux *http.ServeMux, serverURL *url.URL,
 	server := httptest.NewServer(apiHandler)
 
 	baseURL, _ := url.Parse(server.URL + versionPath + "/")
-	client, _ = NewClientWithBaseUrl(token, baseURL.String())
+	client, _ = NewClient(token, WithBaseURL(baseURL.String()))
 
 	return client, mux, baseURL, server.Close
 }

--- a/tests/integration/clerk_test.go
+++ b/tests/integration/clerk_test.go
@@ -3,8 +3,9 @@
 package integration
 
 import (
-	"github.com/clerkinc/clerk-sdk-go/clerk"
 	"os"
+
+	"github.com/clerkinc/clerk-sdk-go/clerk"
 )
 
 type key string
@@ -17,14 +18,12 @@ const (
 func createClient() clerk.Client {
 	apiUrl := getEnv(APIUrl)
 	apiKey := getEnv(APIKey)
-	return createClientWithKey(apiUrl, apiKey)
-}
 
-func createClientWithKey(apiUrl string, apiKey string) clerk.Client {
-	client, err := clerk.NewClientWithBaseUrl(apiKey, apiUrl)
+	client, err := clerk.NewClient(apiKey, clerk.WithBaseURL(apiUrl))
 	if err != nil {
 		panic("Unable to create Clerk client")
 	}
+
 	return client
 }
 


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This PR introduces functional options for our client constructor, that allow to override some of the default settings. 
After this change we won't need to export multiple constructor functions (e.g. `clerk.NewClientWithBaseUrl()`), but a single one `clerk.NewClient()` which will accept some optional parameters.

For example if someone wants to provide their own http client

**Before:**
```golang
customHTTPClient := &http.Client{Timeout: time.Second * 30}

c, err := clerk.NewClientWithCustomHTTP("apiKey", clerk.ProdUrl, customHTTPClient)
```

**After:**
```golang
customHTTPClient := &http.Client{Timeout: time.Second * 30}

c, err := clerk.NewClient("apiKey", clerk.WithHTTPClient(customHTTPClient))
```

The old constructor functions are still present, to ensure backwards compatibility, but marked as deprecated and they will be removed in an upcoming major release

### Related Issue (optional)

<!--- Please link to the issue here: -->
