### PR TITLE
feat: Support for jwt_templates endpoints

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -23,6 +23,7 @@ const (
 	TemplatesUrl     = "templates"
 	UsersUrl         = "users"
 	WebhooksUrl      = "webhooks"
+	JWTTemplatesUrl  = "jwt_templates"
 )
 
 var (
@@ -39,6 +40,7 @@ type Client interface {
 	Clients() *ClientsService
 	Emails() *EmailService
 	JWKS() *JWKSService
+	JWTTemplates() *JWTTemplatesService
 	Sessions() *SessionsService
 	SMS() *SMSService
 	Templates() *TemplatesService
@@ -63,6 +65,7 @@ type client struct {
 	clients      *ClientsService
 	emails       *EmailService
 	jwks         *JWKSService
+	jwtTemplates *JWTTemplatesService
 	sessions     *SessionsService
 	sms          *SMSService
 	templates    *TemplatesService
@@ -100,6 +103,7 @@ func NewClient(token string, options ...ClerkOption) (Client, error) {
 	client.clients = (*ClientsService)(commonService)
 	client.emails = (*EmailService)(commonService)
 	client.jwks = (*JWKSService)(commonService)
+	client.jwtTemplates = (*JWTTemplatesService)(commonService)
 	client.sessions = (*SessionsService)(commonService)
 	client.sms = (*SMSService)(commonService)
 	client.templates = (*TemplatesService)(commonService)
@@ -221,6 +225,10 @@ func (c *client) Emails() *EmailService {
 
 func (c *client) JWKS() *JWKSService {
 	return c.jwks
+}
+
+func (c *client) JWTTemplates() *JWTTemplatesService {
+	return c.jwtTemplates
 }
 
 func (c *client) Sessions() *SessionsService {

--- a/clerk/jwt_templates.go
+++ b/clerk/jwt_templates.go
@@ -1,0 +1,131 @@
+package clerk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type JWTTemplatesService service
+
+type JWTTemplate struct {
+	ID               string          `json:"id"`
+	Object           string          `json:"object"`
+	Name             string          `json:"name"`
+	Claims           json.RawMessage `json:"claims"`
+	Lifetime         int             `json:"lifetime"`
+	AllowedClockSkew int             `json:"allowed_clock_skew"`
+	CreatedAt        int64           `json:"created_at"`
+	UpdatedAt        int64           `json:"updated_at"`
+}
+
+type CreateUpdateJWTTemplate struct {
+	Claims           map[string]interface{}
+	Name             string
+	Lifetime         *int
+	AllowedClockSkew *int
+}
+
+func (t CreateUpdateJWTTemplate) toRequest() (*createUpdateJWTTemplateRequest, error) {
+	claimsBytes, err := json.Marshal(t.Claims)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createUpdateJWTTemplateRequest{
+		Claims:           string(claimsBytes),
+		Name:             t.Name,
+		Lifetime:         t.Lifetime,
+		AllowedClockSkew: t.AllowedClockSkew,
+	}, nil
+}
+
+type createUpdateJWTTemplateRequest struct {
+	Claims           string `json:"claims"`
+	Name             string `json:"name"`
+	Lifetime         *int   `json:"lifetime,omitempty"`
+	AllowedClockSkew *int   `json:"allowed_clock_skew,omitempty"`
+}
+
+func (s JWTTemplatesService) ListAll() ([]JWTTemplate, error) {
+	req, err := s.client.NewRequest(http.MethodGet, JWTTemplatesUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	jwtTemplates := make([]JWTTemplate, 0)
+	if _, err = s.client.Do(req, &jwtTemplates); err != nil {
+		return nil, err
+	}
+
+	return jwtTemplates, nil
+}
+
+func (s JWTTemplatesService) Read(id string) (*JWTTemplate, error) {
+	reqURL := fmt.Sprintf("%s/%s", JWTTemplatesUrl, id)
+	req, err := s.client.NewRequest(http.MethodGet, reqURL)
+	if err != nil {
+		return nil, err
+	}
+
+	jwtTemplate := &JWTTemplate{}
+	if _, err = s.client.Do(req, jwtTemplate); err != nil {
+		return nil, err
+	}
+
+	return jwtTemplate, nil
+}
+
+func (s JWTTemplatesService) Create(params *CreateUpdateJWTTemplate) (*JWTTemplate, error) {
+	reqBody, err := params.toRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewRequest(http.MethodPost, JWTTemplatesUrl, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := JWTTemplate{}
+	if _, err = s.client.Do(req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (s JWTTemplatesService) Update(id string, params *CreateUpdateJWTTemplate) (*JWTTemplate, error) {
+	reqURL := fmt.Sprintf("%s/%s", JWTTemplatesUrl, id)
+
+	reqBody, err := params.toRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewRequest(http.MethodPatch, reqURL, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := JWTTemplate{}
+	if _, err = s.client.Do(req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (s JWTTemplatesService) Delete(id string) (*DeleteResponse, error) {
+	reqURL := fmt.Sprintf("%s/%s", JWTTemplatesUrl, id)
+	req, err := s.client.NewRequest(http.MethodDelete, reqURL)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &DeleteResponse{}
+	if _, err = s.client.Do(req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/clerk/jwt_templates_test.go
+++ b/clerk/jwt_templates_test.go
@@ -1,0 +1,180 @@
+package clerk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJWTTemplatesService_ListAll(t *testing.T) {
+	c, mux, _, teardown := setup("token")
+	defer teardown()
+
+	dummyResponse := "[" + dummyJWTTemplateJSON + "]"
+
+	mux.HandleFunc("/jwt_templates", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodGet)
+		testHeader(t, req, "Authorization", "Bearer token")
+		_, _ = fmt.Fprint(w, dummyResponse)
+	})
+
+	got, err := c.JWTTemplates().ListAll()
+	assert.Nil(t, err)
+
+	expected := make([]JWTTemplate, 0)
+	_ = json.Unmarshal([]byte(dummyResponse), &expected)
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("Response = %v, want %v", got, expected)
+	}
+}
+
+func TestJWTTemplatesService_Read(t *testing.T) {
+	dummyResponse := dummyTemplateJSON
+
+	c, mux, _, teardown := setup("token")
+	defer teardown()
+
+	url := fmt.Sprintf("/jwt_templates/%s", dummyJWTTemplateID)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodGet)
+		testHeader(t, req, "Authorization", "Bearer token")
+		_, _ = fmt.Fprint(w, dummyResponse)
+	})
+
+	got, err := c.JWTTemplates().Read(dummyJWTTemplateID)
+	assert.Nil(t, err)
+
+	expected := JWTTemplate{}
+	_ = json.Unmarshal([]byte(dummyResponse), &expected)
+
+	if !reflect.DeepEqual(*got, expected) {
+		t.Errorf("Response = %v, want %v", got, expected)
+	}
+}
+
+func TestJWTTemplatesService_Create(t *testing.T) {
+	dummyResponse := dummyJWTTemplateJSON
+
+	c, mux, _, teardown := setup("token")
+	defer teardown()
+
+	mux.HandleFunc("/jwt_templates", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodPost)
+		testHeader(t, req, "Authorization", "Bearer token")
+		_, _ = fmt.Fprint(w, dummyResponse)
+	})
+
+	newJWTTmpl := &CreateUpdateJWTTemplate{
+		Name: "Testing",
+		Claims: map[string]interface{}{
+			"name": "{{user.first_name}}",
+			"role": "tester",
+		},
+	}
+
+	got, err := c.JWTTemplates().Create(newJWTTmpl)
+	assert.Nil(t, err)
+
+	expected := JWTTemplate{}
+	_ = json.Unmarshal([]byte(dummyResponse), &expected)
+
+	if !reflect.DeepEqual(*got, expected) {
+		t.Errorf("Response = %v, want %v", got, expected)
+	}
+}
+
+func TestJWTTemplatesService_Update(t *testing.T) {
+	dummyResponse := dummyJWTTemplateUpdateJSON
+
+	c, mux, _, teardown := setup("token")
+	defer teardown()
+
+	url := fmt.Sprintf("/jwt_templates/%s", dummyJWTTemplateID)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodPatch)
+		testHeader(t, req, "Authorization", "Bearer token")
+		_, _ = fmt.Fprint(w, dummyResponse)
+	})
+
+	updateJWTTmpl := &CreateUpdateJWTTemplate{
+		Name: "New-Testing",
+		Claims: map[string]interface{}{
+			"name": "{{user.first_name}}",
+			"age":  28,
+		},
+	}
+
+	got, err := c.JWTTemplates().Update(dummyJWTTemplateID, updateJWTTmpl)
+	assert.Nil(t, err)
+
+	expected := JWTTemplate{}
+	_ = json.Unmarshal([]byte(dummyResponse), &expected)
+
+	if !reflect.DeepEqual(*got, expected) {
+		t.Errorf("Response = %v, want %v", got, expected)
+	}
+}
+
+func TestJWTTemplatesService_Delete(t *testing.T) {
+	c, mux, _, teardown := setup("token")
+	defer teardown()
+
+	url := fmt.Sprintf("/jwt_templates/%s", dummyJWTTemplateID)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodDelete)
+		testHeader(t, req, "Authorization", "Bearer token")
+		response := fmt.Sprintf(`{ "deleted": true, "id": "%s", "object": "jwt_template" }`, dummyJWTTemplateID)
+		_, _ = fmt.Fprint(w, response)
+	})
+
+	expected := DeleteResponse{
+		ID:      dummyJWTTemplateID,
+		Object:  "jwt_template",
+		Deleted: true,
+	}
+
+	got, err := c.JWTTemplates().Delete(dummyJWTTemplateID)
+	assert.Nil(t, err)
+
+	if !reflect.DeepEqual(*got, expected) {
+		t.Errorf("Response = %v, want %v", *got, expected)
+	}
+}
+
+const (
+	dummyJWTTemplateID = "jtmp_21xC2Ziqscwjq43MtC3CN6Pngbo"
+
+	dummyJWTTemplateJSON = `
+{
+    "object": "jwt_template",
+	"id": "` + dummyJWTTemplateID + `",
+    "name": "Testing",
+    "claims": {
+		"name": "{{user.first_name}}",
+		"role": "tester"
+	},
+	"lifetime": 60,
+	"allowed_clock_skew": 5
+}`
+
+	dummyJWTTemplateUpdateJSON = `
+{
+    "object": "jwt_template",
+	"id": "` + dummyJWTTemplateID + `",
+    "name": "New-Testing",
+    "claims": {
+		"name": "{{user.first_name}}",
+		"age": 28
+	},
+	"lifetime": 60,
+	"allowed_clock_skew": 5
+}`
+)

--- a/tests/integration/jwt_templates_test.go
+++ b/tests/integration/jwt_templates_test.go
@@ -1,0 +1,77 @@
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/clerkinc/clerk-sdk-go/clerk"
+)
+
+func TestJWTTemplates(t *testing.T) {
+	c := createClient()
+
+	jwtTemplates, err := c.JWTTemplates().ListAll()
+	if err != nil {
+		t.Fatalf("JWTTemplates.ListAll returned error: %v", err)
+	}
+	if jwtTemplates == nil {
+		t.Fatalf("JWTTemplates.ListAll returned nil")
+	}
+
+	for _, jwtTemplate := range jwtTemplates {
+		tmpl, err := c.JWTTemplates().Read(jwtTemplate.ID)
+		if err != nil {
+			t.Fatalf("JWTTemplates.Read returned error: %v", err)
+		}
+		if tmpl == nil {
+			t.Fatalf("JWTTemplates.Read returned nil")
+		}
+	}
+
+	newJWTTemplate := &clerk.CreateUpdateJWTTemplate{
+		Name: fmt.Sprintf("Integration-%d", time.Now().Unix()),
+		Claims: map[string]interface{}{
+			"name": "{{user.first_name}}",
+			"role": "tester",
+		},
+	}
+
+	jwtTemplate, err := c.JWTTemplates().Create(newJWTTemplate)
+	if err != nil {
+		t.Fatalf("JWTTemplates.Create returned error: %v", err)
+	}
+
+	assert.Equal(t, newJWTTemplate.Name, jwtTemplate.Name)
+	assert.Equal(t, 60, jwtTemplate.Lifetime)
+	assert.Equal(t, 5, jwtTemplate.AllowedClockSkew)
+
+	updateJWTTemplate := &clerk.CreateUpdateJWTTemplate{
+		Name: fmt.Sprintf("Updated-Integration-%d", time.Now().Unix()),
+		Claims: map[string]interface{}{
+			"name": "{{user.first_name}}",
+			"age":  28,
+		},
+	}
+
+	updated, err := c.JWTTemplates().Update(jwtTemplate.ID, updateJWTTemplate)
+	if err != nil {
+		t.Fatalf("JWTTemplates.Create returned error: %v", err)
+	}
+
+	assert.Equal(t, jwtTemplate.ID, updated.ID)
+	assert.Equal(t, updateJWTTemplate.Name, updated.Name)
+
+	expectedClaimsBytes, _ := json.Marshal(updateJWTTemplate.Claims)
+	assert.JSONEq(t, string(expectedClaimsBytes), string(updated.Claims))
+
+	_, err = c.JWTTemplates().Delete(jwtTemplate.ID)
+	if err != nil {
+		t.Fatalf("JWTTemplates.Delete returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Add support for the new JWT templates endpoints. The below operations are available:
- List all available JWT templates of an instance
- Read a single JWT template by ID
- Create a new JWT template
- Update an existing JWT template
- Delete an existing JWT template by ID

### Related Issue (optional)

<!--- Please link to the issue here: -->
