### PR TITLE
feat: Support to verify authorized party (azp) session token claim

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -35,7 +35,7 @@ type Client interface {
 	Do(req *http.Request, v interface{}) (*http.Response, error)
 
 	DecodeToken(token string) (*TokenClaims, error)
-	VerifyToken(token string) (*SessionClaims, error)
+	VerifyToken(token string, opts ...VerifyTokenOption) (*SessionClaims, error)
 
 	Clients() *ClientsService
 	Emails() *EmailService

--- a/clerk/tokens_options.go
+++ b/clerk/tokens_options.go
@@ -1,0 +1,16 @@
+package clerk
+
+// VerifyTokenOption describes a functional parameter for the VerifyToken method
+type VerifyTokenOption func(*verifyTokenOptions)
+
+// WithAuthorizedParty allows to set the authorized parties to check against the azp claim of the session token
+func WithAuthorizedParty(parties ...string) VerifyTokenOption {
+	return func(o *verifyTokenOptions) {
+		authorizedParties := make(map[string]struct{})
+		for _, party := range parties {
+			authorizedParties[party] = struct{}{}
+		}
+
+		o.authorizedParties = authorizedParties
+	}
+}

--- a/clerk/tokens_options_test.go
+++ b/clerk/tokens_options_test.go
@@ -1,0 +1,43 @@
+package clerk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithAuthorizedPartyNone(t *testing.T) {
+	opts := &verifyTokenOptions{}
+	WithAuthorizedParty()(opts)
+
+	assert.Len(t, opts.authorizedParties, 0)
+}
+
+func TestWithAuthorizedPartySingle(t *testing.T) {
+	opts := &verifyTokenOptions{}
+	WithAuthorizedParty("test-party")(opts)
+
+	assert.Len(t, opts.authorizedParties, 1)
+	assert.Equal(t, arrayToMap(t, []string{"test-party"}), opts.authorizedParties)
+}
+
+func TestWithAuthorizedPartyMultiple(t *testing.T) {
+	authorizedParties := []string{"test-party", "another_party", "yet-another-party"}
+
+	opts := &verifyTokenOptions{}
+	WithAuthorizedParty(authorizedParties...)(opts)
+
+	assert.Len(t, opts.authorizedParties, len(authorizedParties))
+	assert.Equal(t, arrayToMap(t, authorizedParties), opts.authorizedParties)
+}
+
+func arrayToMap(t *testing.T, input []string) map[string]struct{} {
+	t.Helper()
+
+	output := make(map[string]struct{})
+	for _, s := range input {
+		output[s] = struct{}{}
+	}
+
+	return output
+}


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Added support to verify the authorized party (azp) claim, if it's included in the session token claims within the VerifyToken method and v2 middlewares

### Related Issue (optional)

<!--- Please link to the issue here: -->
