### PR TITLE
Allow to verify tokens with preconfigured JWK

### DIFF
--- a/clerk/tokens.go
+++ b/clerk/tokens.go
@@ -48,6 +48,7 @@ func (c *client) DecodeToken(token string) (*TokenClaims, error) {
 type verifyTokenOptions struct {
 	authorizedParties map[string]struct{}
 	leeway            time.Duration
+	jwk               *jose.JSONWebKey
 }
 
 // VerifyToken verifies the session jwt token.
@@ -74,9 +75,12 @@ func (c *client) VerifyToken(token string, opts ...VerifyTokenOption) (*SessionC
 		return nil, fmt.Errorf("missing jwt kid header claim")
 	}
 
-	jwk, err := c.getJWK(kid)
-	if err != nil {
-		return nil, err
+	jwk := options.jwk
+	if jwk == nil {
+		jwk, err = c.getJWK(kid)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if parsedToken.Headers[0].Algorithm != jwk.Algorithm {

--- a/clerk/tokens.go
+++ b/clerk/tokens.go
@@ -55,7 +55,9 @@ func (c *client) VerifyToken(token string, opts ...VerifyTokenOption) (*SessionC
 	options := &verifyTokenOptions{}
 
 	for _, opt := range opts {
-		opt(options)
+		if err := opt(options); err != nil {
+			return nil, err
+		}
 	}
 
 	parsedToken, err := jwt.ParseSigned(token)

--- a/clerk/tokens_options.go
+++ b/clerk/tokens_options.go
@@ -1,6 +1,14 @@
 package clerk
 
-import "time"
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+
+	"gopkg.in/square/go-jose.v2"
+)
 
 // VerifyTokenOption describes a functional parameter for the VerifyToken method
 type VerifyTokenOption func(*verifyTokenOptions) error
@@ -24,4 +32,42 @@ func WithLeeway(leeway time.Duration) VerifyTokenOption {
 		o.leeway = leeway
 		return nil
 	}
+}
+
+// WithJWTVerificationKey allows to set the JWK to use for verifying tokens without the need to download or cache any JWKs at runtime
+func WithJWTVerificationKey(key string) VerifyTokenOption {
+	return func(o *verifyTokenOptions) error {
+		// From the Clerk docs: "Note that the JWT Verification key is not in
+		// PEM format, the header and footer are missing, in order to be shorter
+		// and single-line for easier setup."
+		if !strings.HasPrefix(key, "-----BEGIN") {
+			key = "-----BEGIN PUBLIC KEY-----\n" + key + "\n-----END PUBLIC KEY-----"
+		}
+
+		jwk, err := pemToJWK(key)
+		if err != nil {
+			return err
+		}
+
+		o.jwk = jwk
+		return nil
+	}
+}
+
+func pemToJWK(key string) (*jose.JSONWebKey, error) {
+	block, _ := pem.Decode([]byte(key))
+	if block == nil {
+		return nil, fmt.Errorf("invalid PEM-encoded block")
+	}
+
+	if block.Type != "PUBLIC KEY" {
+		return nil, fmt.Errorf("invalid key type, expected a public key")
+	}
+
+	rsaPublicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key: %v", err)
+	}
+
+	return &jose.JSONWebKey{Key: rsaPublicKey, Algorithm: "RS256"}, nil
 }

--- a/clerk/tokens_options.go
+++ b/clerk/tokens_options.go
@@ -3,23 +3,25 @@ package clerk
 import "time"
 
 // VerifyTokenOption describes a functional parameter for the VerifyToken method
-type VerifyTokenOption func(*verifyTokenOptions)
+type VerifyTokenOption func(*verifyTokenOptions) error
 
 // WithAuthorizedParty allows to set the authorized parties to check against the azp claim of the session token
 func WithAuthorizedParty(parties ...string) VerifyTokenOption {
-	return func(o *verifyTokenOptions) {
+	return func(o *verifyTokenOptions) error {
 		authorizedParties := make(map[string]struct{})
 		for _, party := range parties {
 			authorizedParties[party] = struct{}{}
 		}
 
 		o.authorizedParties = authorizedParties
+		return nil
 	}
 }
 
 // WithLeeway allows to set a custom leeway that gives some extra time to the token to accomodate for clock skew, etc.
 func WithLeeway(leeway time.Duration) VerifyTokenOption {
-	return func(o *verifyTokenOptions) {
+	return func(o *verifyTokenOptions) error {
 		o.leeway = leeway
+		return nil
 	}
 }

--- a/clerk/tokens_options_test.go
+++ b/clerk/tokens_options_test.go
@@ -20,10 +20,9 @@ func TestWithAuthorizedPartySingle(t *testing.T) {
 	opts := &verifyTokenOptions{}
 	err := WithAuthorizedParty("test-party")(opts)
 
-	if assert.NoError(t, err) {
-		assert.Len(t, opts.authorizedParties, 1)
-		assert.Equal(t, arrayToMap(t, []string{"test-party"}), opts.authorizedParties)
-	}
+	assert.NoError(t, err)
+	assert.Len(t, opts.authorizedParties, 1)
+	assert.Equal(t, arrayToMap(t, []string{"test-party"}), opts.authorizedParties)
 }
 
 func TestWithAuthorizedPartyMultiple(t *testing.T) {
@@ -32,10 +31,9 @@ func TestWithAuthorizedPartyMultiple(t *testing.T) {
 	opts := &verifyTokenOptions{}
 	err := WithAuthorizedParty(authorizedParties...)(opts)
 
-	if assert.NoError(t, err) {
-		assert.Len(t, opts.authorizedParties, len(authorizedParties))
-		assert.Equal(t, arrayToMap(t, authorizedParties), opts.authorizedParties)
-	}
+	assert.NoError(t, err)
+	assert.Len(t, opts.authorizedParties, len(authorizedParties))
+	assert.Equal(t, arrayToMap(t, authorizedParties), opts.authorizedParties)
 }
 
 func TestWithLeeway(t *testing.T) {
@@ -44,9 +42,8 @@ func TestWithLeeway(t *testing.T) {
 	opts := &verifyTokenOptions{}
 	err := WithLeeway(leeway)(opts)
 
-	if assert.NoError(t, err) {
-		assert.Equal(t, opts.leeway, leeway)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, opts.leeway, leeway)
 }
 
 func TestWithJWTVerificationKey(t *testing.T) {

--- a/clerk/tokens_options_test.go
+++ b/clerk/tokens_options_test.go
@@ -9,36 +9,44 @@ import (
 
 func TestWithAuthorizedPartyNone(t *testing.T) {
 	opts := &verifyTokenOptions{}
-	WithAuthorizedParty()(opts)
+	err := WithAuthorizedParty()(opts)
 
-	assert.Len(t, opts.authorizedParties, 0)
+	if assert.NoError(t, err) {
+		assert.Len(t, opts.authorizedParties, 0)
+	}
 }
 
 func TestWithAuthorizedPartySingle(t *testing.T) {
 	opts := &verifyTokenOptions{}
-	WithAuthorizedParty("test-party")(opts)
+	err := WithAuthorizedParty("test-party")(opts)
 
-	assert.Len(t, opts.authorizedParties, 1)
-	assert.Equal(t, arrayToMap(t, []string{"test-party"}), opts.authorizedParties)
+	if assert.NoError(t, err) {
+		assert.Len(t, opts.authorizedParties, 1)
+		assert.Equal(t, arrayToMap(t, []string{"test-party"}), opts.authorizedParties)
+	}
 }
 
 func TestWithAuthorizedPartyMultiple(t *testing.T) {
 	authorizedParties := []string{"test-party", "another_party", "yet-another-party"}
 
 	opts := &verifyTokenOptions{}
-	WithAuthorizedParty(authorizedParties...)(opts)
+	err := WithAuthorizedParty(authorizedParties...)(opts)
 
-	assert.Len(t, opts.authorizedParties, len(authorizedParties))
-	assert.Equal(t, arrayToMap(t, authorizedParties), opts.authorizedParties)
+	if assert.NoError(t, err) {
+		assert.Len(t, opts.authorizedParties, len(authorizedParties))
+		assert.Equal(t, arrayToMap(t, authorizedParties), opts.authorizedParties)
+	}
 }
 
 func TestWithLeeway(t *testing.T) {
 	leeway := 5 * time.Second
 
 	opts := &verifyTokenOptions{}
-	WithLeeway(leeway)(opts)
+	err := WithLeeway(leeway)(opts)
 
-	assert.Equal(t, opts.leeway, leeway)
+	if assert.NoError(t, err) {
+		assert.Equal(t, opts.leeway, leeway)
+	}
 }
 
 func arrayToMap(t *testing.T, input []string) map[string]struct{} {

--- a/clerk/tokens_options_test.go
+++ b/clerk/tokens_options_test.go
@@ -49,6 +49,36 @@ func TestWithLeeway(t *testing.T) {
 	}
 }
 
+func TestWithJWTVerificationKey(t *testing.T) {
+	key := "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm7Zs5PFGrsrmvys1hHkSDOYoghz9+z9o+E6WgMqR+R/Af0/QRqQo/YwCmzB+01+5Us1NdSa32YuQYiMxV4T+g3eebSiBqPNiCyjl2wttCm5LAV5iHyVqwnBNcrXlA5mRFQz8lmyfpoksNDEVzJPwwHzPjKSIKsGgsrPnw6XsyOPJY/8UocscEcHptTmahHrbfNZLN0FrMneHw9tnn2AiUctuU9bw80KwPd+WFdZ6UZF/kPxVFsANJpz1aMpz7Lxi3Sz1ztUCdHvNJitRUO1Qewby4xi9DfIEECMq78LLmwGaTiKxutC6KwHLJEcbUblOJHpYVEXdBex9xGJ/2DHrBQIDAQAB"
+
+	opts := &verifyTokenOptions{}
+	err := WithJWTVerificationKey(key)(opts)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "RS256", opts.jwk.Algorithm)
+	}
+}
+
+func TestWithJWTVerificationKey_PEM(t *testing.T) {
+	key := `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm7Zs5PFGrsrmvys1hHkS
+DOYoghz9+z9o+E6WgMqR+R/Af0/QRqQo/YwCmzB+01+5Us1NdSa32YuQYiMxV4T+
+g3eebSiBqPNiCyjl2wttCm5LAV5iHyVqwnBNcrXlA5mRFQz8lmyfpoksNDEVzJPw
+wHzPjKSIKsGgsrPnw6XsyOPJY/8UocscEcHptTmahHrbfNZLN0FrMneHw9tnn2Ai
+UctuU9bw80KwPd+WFdZ6UZF/kPxVFsANJpz1aMpz7Lxi3Sz1ztUCdHvNJitRUO1Q
+ewby4xi9DfIEECMq78LLmwGaTiKxutC6KwHLJEcbUblOJHpYVEXdBex9xGJ/2DHr
+BQIDAQAB
+-----END PUBLIC KEY-----`
+
+	opts := &verifyTokenOptions{}
+	err := WithJWTVerificationKey(key)(opts)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "RS256", opts.jwk.Algorithm)
+	}
+}
+
 func arrayToMap(t *testing.T, input []string) map[string]struct{} {
 	t.Helper()
 

--- a/clerk/tokens_test.go
+++ b/clerk/tokens_test.go
@@ -264,6 +264,20 @@ func TestClient_VerifyToken_Success_WithJWTVerificationKey(t *testing.T) {
 	}
 }
 
+func TestClient_VerifyToken_Error_WithJWTVerificationKey(t *testing.T) {
+	c, _ := NewClient("token")
+	token, _ := testGenerateTokenJWT(t, dummySessionClaims, "kid")
+
+	// Generate new public key not matching the one from the token
+	_, pubKey := testGenerateTokenJWT(t, dummySessionClaims, "kid")
+	verificationKey := testRSAPublicKeyToPEM(t, pubKey)
+
+	_, err := c.VerifyToken(token, WithJWTVerificationKey(verificationKey))
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
 func testGenerateTokenJWT(t *testing.T, claims interface{}, kid string) (string, crypto.PublicKey) {
 	t.Helper()
 


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This PR makes it possible to use Clerk's [JWT Verification Key](https://docs.clerk.dev/popular-guides/validating-session-tokens) in serverless environments.

The key can be constructed from PEM via https://pkg.go.dev/go.step.sm/crypto/jose#ParseKey