### PR TITLE
Added endpoint to get total count of users

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -25,6 +25,7 @@ const (
 	SMSUrl           = "sms_messages"
 	TemplatesUrl     = "templates"
 	UsersUrl         = "users"
+	UsersCountUrl    = UsersUrl + "/count"
 	WebhooksUrl      = "webhooks"
 	JWTTemplatesUrl  = "jwt_templates"
 )

--- a/clerk/users.go
+++ b/clerk/users.go
@@ -56,6 +56,11 @@ type ListAllUsersParams struct {
 	Offset         *int
 	EmailAddresses []string
 	PhoneNumbers   []string
+	Web3Wallets    []string
+	Usernames      []string
+	UserIDs        []string
+	Query          *string
+	OrderBy        *string
 }
 
 func (s *UsersService) ListAll(params ListAllUsersParams) ([]User, error) {
@@ -77,6 +82,27 @@ func (s *UsersService) ListAll(params ListAllUsersParams) ([]User, error) {
 		for _, phone := range params.PhoneNumbers {
 			query.Add("phone_number", phone)
 		}
+	}
+	if params.Web3Wallets != nil {
+		for _, web3Wallet := range params.Web3Wallets {
+			query.Add("web3_wallet", web3Wallet)
+		}
+	}
+	if params.Usernames != nil {
+		for _, username := range params.Usernames {
+			query.Add("username", username)
+		}
+	}
+	if params.UserIDs != nil {
+		for _, userID := range params.UserIDs {
+			query.Add("user_id", userID)
+		}
+	}
+	if params.Query != nil {
+		query.Add("query", *params.Query)
+	}
+	if params.OrderBy != nil {
+		query.Add("order_by", *params.OrderBy)
 	}
 	req.URL.RawQuery = query.Encode()
 

--- a/clerk/users_test.go
+++ b/clerk/users_test.go
@@ -52,6 +52,11 @@ func TestUsersService_ListAll_happyPathWithParameters(t *testing.T) {
 			"offset":        {"6"},
 			"email_address": {"email1", "email2"},
 			"phone_number":  {"phone1", "phone2"},
+			"web3_wallet":   {"wallet1", "wallet2"},
+			"username":      {"username1", "username2"},
+			"user_id":       {"userid1", "userid2"},
+			"query":         {"my-query"},
+			"order_by":      {"created_at"},
 		})
 		assert.Equal(t, expectedQuery, actualQuery)
 		fmt.Fprint(w, expectedResponse)
@@ -62,11 +67,18 @@ func TestUsersService_ListAll_happyPathWithParameters(t *testing.T) {
 
 	limit := 5
 	offset := 6
+	queryString := "my-query"
+	orderBy := "created_at"
 	got, _ := client.Users().ListAll(ListAllUsersParams{
 		Limit:          &limit,
 		Offset:         &offset,
 		EmailAddresses: []string{"email1", "email2"},
 		PhoneNumbers:   []string{"phone1", "phone2"},
+		Web3Wallets:    []string{"wallet1", "wallet2"},
+		Usernames:      []string{"username1", "username2"},
+		UserIDs:        []string{"userid1", "userid2"},
+		Query:          &queryString,
+		OrderBy:        &orderBy,
 	})
 	if len(got) != len(want) {
 		t.Errorf("Was expecting %d user to be returned, instead got %d", len(want), len(got))

--- a/tests/integration/templates_test.go
+++ b/tests/integration/templates_test.go
@@ -36,7 +36,7 @@ func TestTemplates(t *testing.T) {
 
 		var requiredVariable string
 		switch slug {
-		case "invitation":
+		case "invitation", "organization_invitation":
 			requiredVariable = "{{ActionURL}}"
 		case "magic_link":
 			requiredVariable = "{{MagicLink}}"

--- a/tests/integration/users_test.go
+++ b/tests/integration/users_test.go
@@ -33,6 +33,14 @@ func TestUsers(t *testing.T) {
 		t.Fatalf("Users.ListAll returned nil")
 	}
 
+	userCount, err := client.Users().Count(clerk.ListAllUsersParams{})
+	if err != nil {
+		t.Fatalf("Users.Count returned error: %v", err)
+	}
+	if userCount.TotalCount != len(users) {
+		t.Fatalf("Users.Count returned %d, expected %d", userCount.TotalCount, len(users))
+	}
+
 	for i, user := range users {
 		userId := user.ID
 		user, err := client.Users().Read(userId)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This PR includes two changes:
* Adds some missing params on the list users which are supported by our BAPI endpoint. Namely, it allows to filter users based on web3 wallets, usernames, user ids or a query. It also allows to order users by particular properties.
* Adds the new users count endpoint which return the total count of users that match the filtering params given. This is particularly helpful for callers who need to know the total count in order to properly use the limit/offset capabilities of our list users method. _Please note_ that this is a temporary solution until we properly implement pagination responses.

### Related Issue (optional)

https://www.notion.so/clerkdev/Return-user-total-count-in-BAPI-771264a4fccc461984f98003b0204499
