### PR TITLE
feat: Introduce Raw field in SessionClaims struct

### DIFF
--- a/clerk/middleware_test.go
+++ b/clerk/middleware_test.go
@@ -113,6 +113,7 @@ func TestWithSession_addSessionClaimsToContext_Header(t *testing.T) {
 
 	var got SessionClaims
 	_ = json.NewDecoder(resp.Body).Decode(&got)
+	got.Raw = make(map[string]interface{})
 
 	if !reflect.DeepEqual(got, expectedClaims) {
 		t.Errorf("Response = %v, want %v", got, expectedClaims)
@@ -155,6 +156,7 @@ func TestWithSession_addSessionClaimsToContext_Cookie(t *testing.T) {
 
 	var got SessionClaims
 	_ = json.NewDecoder(resp.Body).Decode(&got)
+	got.Raw = make(map[string]interface{})
 
 	if !reflect.DeepEqual(got, expectedClaims) {
 		t.Errorf("Response = %v, want %v", got, expectedClaims)

--- a/clerk/tokens.go
+++ b/clerk/tokens.go
@@ -20,7 +20,8 @@ type TokenClaims struct {
 type SessionClaims struct {
 	jwt.Claims
 	SessionID       string `json:"sid"`
-	AuthorizedParty string `json:"azp"`
+	AuthorizedParty string `json:"azp,omitempty"`
+	Raw             map[string]interface{}
 }
 
 // DecodeToken decodes a jwt token without verifying it.
@@ -88,7 +89,8 @@ func (c *client) VerifyToken(token string, opts ...VerifyTokenOption) (*SessionC
 	}
 
 	claims := SessionClaims{}
-	if err = parsedToken.Claims(jwk.Key, &claims); err != nil {
+	rawClaims := make(map[string]interface{})
+	if err = parsedToken.Claims(jwk.Key, &claims, &rawClaims); err != nil {
 		return nil, err
 	}
 
@@ -106,6 +108,7 @@ func (c *client) VerifyToken(token string, opts ...VerifyTokenOption) (*SessionC
 		}
 	}
 
+	claims.Raw = rawClaims
 	return &claims, nil
 }
 


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Introduce a new Raw field in the SessionClaims struct. This will be populated with every key that it's included in the provided JWT token

### Related Issue (optional)

https://github.com/clerkinc/clerk-sdk-go/issues/53
