### PR TITLE
feat: Introduce VerifyToken WithCustomClaims option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ and respond with 403 if the user is not authenticated.
 Finally, to retrieve the authenticated session's claims you can use 
 `clerk.SessionFromContext()`.
 
+### Additional options
+The new middlewares (`clerk.WithSessionV2()` & `clerk.RequireSessionV2()`) also support the ability to pass some additional options.
+- clerk.WithAuthorizedParty() to set the authorized parties to check against the azp claim of the token
+- clerk.WithLeeway() to set a custom leeway that gives some extra time to the token to accommodate for clock skew
+- clerk.WithJWTVerificationKey() to set the JWK to use for verifying tokens without the need to fetch or cache any JWKs at runtime 
+- clerk.WithCustomClaims() to pass a type (e.g. struct), which will be populated with the token claims based on json tags.
+
+For example 
+```golang
+customClaims := myCustomClaimsStruct{}
+
+clerk.WithSessionV2(
+	clerkClient, 
+	clerk.WithAuthorizedParty("my-authorized-party"), 
+	clerk.WithLeeway(5 * time.Second),
+	clerk.WithCustomClaims(&customClaims),
+	)
+```
+
 ## License ##
 
 This SDK is licensed under the MIT license found in the [LICENSE](./LICENSE) file.

--- a/clerk/tokens_options.go
+++ b/clerk/tokens_options.go
@@ -54,6 +54,15 @@ func WithJWTVerificationKey(key string) VerifyTokenOption {
 	}
 }
 
+// WithCustomClaims allows to pass a type (e.g. struct), which will be populated with the token claims based on json tags.
+// For this option to work you must pass a pointer.
+func WithCustomClaims(customClaims interface{}) VerifyTokenOption {
+	return func(o *verifyTokenOptions) error {
+		o.customClaims = customClaims
+		return nil
+	}
+}
+
 func pemToJWK(key string) (*jose.JSONWebKey, error) {
 	block, _ := pem.Decode([]byte(key))
 	if block == nil {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Introduce a new option WithCustomClaims for the VerifyToken() method. This will allow users to retrieve any custom claims that a token may contain after a successful verification.

### Related Issue (optional)

https://github.com/clerkinc/clerk-sdk-go/issues/53
