### PR TITLE
feat: Allow list all orgs to optionally include members count in the response

### DIFF
--- a/clerk/organizations.go
+++ b/clerk/organizations.go
@@ -14,6 +14,7 @@ type Organization struct {
 	Name            string          `json:"name"`
 	Slug            *string         `json:"slug"`
 	LogoURL         *string         `json:"logo_url"`
+	MembersCount    int             `json:"members_count,omitempty"`
 	PublicMetadata  json.RawMessage `json:"public_metadata"`
 	PrivateMetadata json.RawMessage `json:"private_metadata,omitempty"`
 	CreatedAt       int64           `json:"created_at"`
@@ -26,8 +27,9 @@ type OrganizationsResponse struct {
 }
 
 type ListAllOrganizationsParams struct {
-	Limit  *int
-	Offset *int
+	Limit               *int
+	Offset              *int
+	IncludeMembersCount bool
 }
 
 func (s *OrganizationsService) ListAll(params ListAllOrganizationsParams) (*OrganizationsResponse, error) {
@@ -39,6 +41,9 @@ func (s *OrganizationsService) ListAll(params ListAllOrganizationsParams) (*Orga
 	}
 	if params.Offset != nil {
 		query.Set("offset", strconv.Itoa(*params.Offset))
+	}
+	if params.IncludeMembersCount {
+		query.Set("include_members_count", strconv.FormatBool(params.IncludeMembersCount))
 	}
 	req.URL.RawQuery = query.Encode()
 

--- a/clerk/organizations_test.go
+++ b/clerk/organizations_test.go
@@ -54,8 +54,9 @@ func TestOrganizationsService_ListAll_happyPathWithParameters(t *testing.T) {
 
 		actualQuery := req.URL.Query()
 		expectedQuery := url.Values(map[string][]string{
-			"limit":  {"5"},
-			"offset": {"6"},
+			"limit":                 {"5"},
+			"offset":                {"6"},
+			"include_members_count": {"true"},
 		})
 		assert.Equal(t, expectedQuery, actualQuery)
 		fmt.Fprint(w, expectedResponse)
@@ -67,8 +68,9 @@ func TestOrganizationsService_ListAll_happyPathWithParameters(t *testing.T) {
 	limit := 5
 	offset := 6
 	got, _ := client.Organizations().ListAll(ListAllOrganizationsParams{
-		Limit:  &limit,
-		Offset: &offset,
+		Limit:               &limit,
+		Offset:              &offset,
+		IncludeMembersCount: true,
 	})
 	if len(got.Data) != len(want.Data) {
 		t.Errorf("Was expecting %d organizations to be returned, instead got %d", len(want.Data), len(got.Data))
@@ -96,6 +98,7 @@ const dummyOrganizationJson = `{
         "id": "org_1mebQggrD3xO5JfuHk7clQ94ysA",
         "name": "test-org",
         "slug": "org_slug",
+		"members_count": 42,
         "created_at": 1610783813,
         "updated_at": 1610783813,
 		"public_metadata": {

--- a/tests/integration/organizations_test.go
+++ b/tests/integration/organizations_test.go
@@ -13,7 +13,9 @@ import (
 func TestOrganizations(t *testing.T) {
 	client := createClient()
 
-	organizations, err := client.Organizations().ListAll(clerk.ListAllOrganizationsParams{})
+	organizations, err := client.Organizations().ListAll(clerk.ListAllOrganizationsParams{
+		IncludeMembersCount: true,
+	})
 	if err != nil {
 		t.Fatalf("Organizations.ListAll returned error: %v", err)
 	}
@@ -23,4 +25,7 @@ func TestOrganizations(t *testing.T) {
 
 	assert.Greater(t, len(organizations.Data), 0)
 	assert.Greater(t, organizations.TotalCount, int64(0))
+	for _, organization := range organizations.Data {
+		assert.Greater(t, organization.MembersCount, 0)
+	}
 }


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This PR allows the organizations `ListAll` method to optional include the members count of each organization in the returned response.

### Related Issue (optional)

<!--- Please link to the issue here: -->
