### PR TITLE
feat: Added Users.UpdateMetadata method

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const version = "1.8.0"
+const version = "1.9.0"
 
 const (
 	ProdUrl = "https://api.clerk.dev/v1/"

--- a/clerk/users.go
+++ b/clerk/users.go
@@ -186,3 +186,21 @@ func (s *UsersService) Update(userId string, updateRequest *UpdateUser) (*User, 
 	}
 	return &updatedUser, nil
 }
+
+type UpdateUserMetadata struct {
+	PublicMetadata  interface{} `json:"public_metadata"`
+	PrivateMetadata interface{} `json:"private_metadata"`
+	UnsafeMetadata  interface{} `json:"unsafe_metadata"`
+}
+
+func (s *UsersService) UpdateMetadata(userId string, updateMetadataRequest *UpdateUserMetadata) (*User, error) {
+	updateUserMetadataURL := fmt.Sprintf("%s/%s/metadata", UsersUrl, userId)
+	req, _ := s.client.NewRequest(http.MethodPatch, updateUserMetadataURL, updateMetadataRequest)
+
+	var updatedUser User
+	_, err := s.client.Do(req, &updatedUser)
+	if err != nil {
+		return nil, err
+	}
+	return &updatedUser, nil
+}

--- a/tests/integration/users_test.go
+++ b/tests/integration/users_test.go
@@ -18,8 +18,9 @@ type userAddress struct {
 	Address addressDetails `json:"address"`
 }
 
-type userAppID struct {
-	AppID int `json:"app_id"`
+type userAppAndContactID struct {
+	AppID     int `json:"app_id"`
+	ContactID int `json:"contact_id"`
 }
 
 func TestUsers(t *testing.T) {
@@ -58,7 +59,7 @@ func TestUsers(t *testing.T) {
 				Street: "Fifth Avenue",
 				Number: "890",
 			}},
-			PrivateMetadata: userAppID{AppID: i},
+			PrivateMetadata: userAppAndContactID{AppID: i},
 		}
 		updatedUser, err := client.Users().Update(userId, &updateRequest)
 		if err != nil {
@@ -66,6 +67,18 @@ func TestUsers(t *testing.T) {
 		}
 		if updatedUser == nil {
 			t.Errorf("Users.Update returned nil")
+		}
+
+		updatedUser, err = client.Users().UpdateMetadata(userId, &clerk.UpdateUserMetadata{
+			PrivateMetadata: userAppAndContactID{
+				ContactID: i,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Users.UpdateMetadata returned error: %v", err)
+		}
+		if updatedUser == nil {
+			t.Errorf("Users.UpdateMetadata returned nil")
 		}
 	}
 }


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This commit adds a new function on the Users, called `UpdateMetadata`.
This is responsible for updating the metadata of the given user. This operation is additive, which means that you don't have to pass the whole metadata object, just the part you want to update/add and it will do the necessary action on its own.

### Related Issue (optional)

<!--- Please link to the issue here: -->
