### PR TITLE
fix: If the request contains a body, include content type header

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -159,7 +159,9 @@ func (c *client) NewRequest(method, url string, body ...interface{}) (*http.Requ
 	}
 
 	var buf io.ReadWriter
+	var hasBody bool
 	if len(body) > 0 && body[0] != nil {
+		hasBody = true
 		buf = &bytes.Buffer{}
 		enc := json.NewEncoder(buf)
 		enc.SetEscapeHTML(false)
@@ -172,6 +174,10 @@ func (c *client) NewRequest(method, url string, body ...interface{}) (*http.Requ
 	req, err := http.NewRequest(method, fullUrl.String(), buf)
 	if err != nil {
 		return nil, err
+	}
+
+	if hasBody {
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	// Add custom header with the current SDK version

--- a/clerk/clerk_test.go
+++ b/clerk/clerk_test.go
@@ -87,6 +87,9 @@ func TestNewRequest_noBody(t *testing.T) {
 	if req.Body != nil {
 		t.Fatalf("Expected nil Body but request contains a non-nil Body")
 	}
+	if req.Header.Get("Content-Type") != "" {
+		t.Fatalf("Expected empty Content-Type header but request contains %q", req.Header.Get("Content-Type"))
+	}
 }
 
 func TestNewRequest_nilBody(t *testing.T) {
@@ -94,6 +97,9 @@ func TestNewRequest_nilBody(t *testing.T) {
 	req, _ := client.NewRequest("GET", ".", nil)
 	if req.Body != nil {
 		t.Fatalf("Expected nil Body but request contains a non-nil Body")
+	}
+	if req.Header.Get("Content-Type") != "" {
+		t.Fatalf("Expected empty Content-Type header but request contains %q", req.Header.Get("Content-Type"))
 	}
 }
 
@@ -110,6 +116,10 @@ func TestNewRequest_withBody(t *testing.T) {
 	body, _ := ioutil.ReadAll(req.Body)
 	if got, want := string(body), outBody; got != want {
 		t.Errorf("NewRequest(%q) Body is %v, want %v", inBody, got, want)
+	}
+
+	if req.Header.Get("Content-Type") != "application/json" {
+		t.Fatalf("Expected application/json Content-Type header but request contains %q", req.Header.Get("Content-Type"))
 	}
 }
 


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

If the request we'll be sending contains a body, we should include the `Content-Type` header with value `application/json`.

### Related Issue (optional)

<!--- Please link to the issue here: -->
