### PR TITLE
feat: Added support email on the settings that can be configured in an instance

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const version = "1.10.0"
+const version = "1.11.0"
 
 const (
 	ProdUrl = "https://api.clerk.dev/v1/"

--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -16,6 +16,12 @@ type UpdateInstanceParams struct {
 	// known security breaches.
 	// By default, this is enabled in all instances.
 	HIBP *bool `json:"hibp,omitempty"`
+
+	// SupportEmail is the contact email address that will be displayed
+	// on the frontend, in case your instance users need support.
+	// If the empty string is provided, the support email that is currently
+	// configured in the instance will be removed.
+	SupportEmail *string `json:"support_email,omitempty"`
 }
 
 func (s *InstanceService) Update(params UpdateInstanceParams) error {

--- a/clerk/instances_test.go
+++ b/clerk/instances_test.go
@@ -17,9 +17,11 @@ func TestInstanceService_Update_happyPath(t *testing.T) {
 	})
 
 	enabled := true
+	supportEmail := "support@clerk.dev"
 	err := client.Instances().Update(UpdateInstanceParams{
-		TestMode: &enabled,
-		HIBP:     &enabled,
+		TestMode:     &enabled,
+		HIBP:         &enabled,
+		SupportEmail: &supportEmail,
 	})
 
 	if err != nil {
@@ -31,9 +33,11 @@ func TestInstanceService_Update_invalidServer(t *testing.T) {
 	client, _ := NewClient("token")
 
 	enabled := true
+	supportEmail := "support@clerk.dev"
 	err := client.Instances().Update(UpdateInstanceParams{
-		TestMode: &enabled,
-		HIBP:     &enabled,
+		TestMode:     &enabled,
+		HIBP:         &enabled,
+		SupportEmail: &supportEmail,
 	})
 	if err == nil {
 		t.Errorf("Expected error to be returned")

--- a/tests/integration/instances_test.go
+++ b/tests/integration/instances_test.go
@@ -13,9 +13,11 @@ func TestInstances(t *testing.T) {
 	client := createClient()
 
 	enabled := true
+	supportEmail := "support@example.com"
 	err := client.Instances().Update(clerk.UpdateInstanceParams{
-		TestMode: &enabled,
-		HIBP:     &enabled,
+		TestMode:     &enabled,
+		HIBP:         &enabled,
+		SupportEmail: &supportEmail,
 	})
 	if err != nil {
 		t.Fatalf("Instances.Update returned error: %v", err)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Updated params of `Instances.Update` to include `support_email`.
This is the email address that will be displayed in the frontend, when the instance users require support.

### Related Issue (optional)

<!--- Please link to the issue here: -->
