### PR TITLE
feat: Added methods for handling redirect urls

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const version = "1.12.0"
+const version = "1.13.0"
 
 const (
 	ProdUrl = "https://api.clerk.dev/v1/"

--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -22,6 +22,7 @@ const (
 	ClientsVerifyUrl = ClientsUrl + "/verify"
 	EmailsUrl        = "emails"
 	OrganizationsUrl = "organizations"
+	RedirectURLsUrl  = "redirect_urls"
 	SessionsUrl      = "sessions"
 	SMSUrl           = "sms_messages"
 	TemplatesUrl     = "templates"
@@ -46,6 +47,7 @@ type Client interface {
 	JWKS() *JWKSService
 	JWTTemplates() *JWTTemplatesService
 	Organizations() *OrganizationsService
+	RedirectURLs() *RedirectURLsService
 	Sessions() *SessionsService
 	SMS() *SMSService
 	Templates() *TemplatesService
@@ -73,6 +75,7 @@ type client struct {
 	jwks          *JWKSService
 	jwtTemplates  *JWTTemplatesService
 	organizations *OrganizationsService
+	redirectURLs  *RedirectURLsService
 	sessions      *SessionsService
 	sms           *SMSService
 	templates     *TemplatesService
@@ -113,6 +116,7 @@ func NewClient(token string, options ...ClerkOption) (Client, error) {
 	client.jwks = (*JWKSService)(commonService)
 	client.jwtTemplates = (*JWTTemplatesService)(commonService)
 	client.organizations = (*OrganizationsService)(commonService)
+	client.redirectURLs = (*RedirectURLsService)(commonService)
 	client.sessions = (*SessionsService)(commonService)
 	client.sms = (*SMSService)(commonService)
 	client.templates = (*TemplatesService)(commonService)
@@ -249,6 +253,10 @@ func (c *client) JWTTemplates() *JWTTemplatesService {
 
 func (c *client) Organizations() *OrganizationsService {
 	return c.organizations
+}
+
+func (c *client) RedirectURLs() *RedirectURLsService {
+	return c.redirectURLs
 }
 
 func (c *client) Sessions() *SessionsService {

--- a/clerk/redirect_urls.go
+++ b/clerk/redirect_urls.go
@@ -1,0 +1,50 @@
+package clerk
+
+import "net/http"
+
+type RedirectURLsService service
+
+type RedirectURLResponse struct {
+	Object    string `json:"object"`
+	ID        string `json:"id"`
+	URL       string `json:"url"`
+	CreatedAt int64  `json:"created_at"`
+	UpdatedAt int64  `json:"updated_at"`
+}
+
+type CreateRedirectURLParams struct {
+	URL string `json:"url"`
+}
+
+func (s *RedirectURLsService) Create(params CreateRedirectURLParams) (*RedirectURLResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodPost, RedirectURLsUrl, &params)
+
+	var redirectURLResponse RedirectURLResponse
+	_, err := s.client.Do(req, &redirectURLResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &redirectURLResponse, nil
+}
+
+func (s *RedirectURLsService) ListAll() ([]*RedirectURLResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodGet, RedirectURLsUrl, nil)
+
+	var redirectURLResponses []*RedirectURLResponse
+	_, err := s.client.Do(req, &redirectURLResponses)
+	if err != nil {
+		return nil, err
+	}
+	return redirectURLResponses, nil
+}
+
+func (s *RedirectURLsService) Delete(redirectURLID string) (*DeleteResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodDelete, RedirectURLsUrl+"/"+redirectURLID, nil)
+
+	var deleteResponse DeleteResponse
+	_, err := s.client.Do(req, &deleteResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &deleteResponse, nil
+}

--- a/clerk/redirect_urls_test.go
+++ b/clerk/redirect_urls_test.go
@@ -1,0 +1,106 @@
+package clerk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedirectURLService_Create_happyPath(t *testing.T) {
+	token := "token"
+	var redirectURLResponse RedirectURLResponse
+	_ = json.Unmarshal([]byte(dummyRedirectURLJson), &redirectURLResponse)
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	mux.HandleFunc("/redirect_urls", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodPost)
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, dummyRedirectURLJson)
+	})
+
+	got, err := client.RedirectURLs().Create(CreateRedirectURLParams{
+		URL: redirectURLResponse.URL,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, *got, redirectURLResponse)
+}
+
+func TestRedirectURLService_Create_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	_, err := client.RedirectURLs().Create(CreateRedirectURLParams{
+		URL: "example.com",
+	})
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
+func TestRedirectURLService_ListAll_happyPath(t *testing.T) {
+	token := "token"
+	var redirectURLResponse RedirectURLResponse
+	_ = json.Unmarshal([]byte(dummyRedirectURLJson), &redirectURLResponse)
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	mux.HandleFunc("/redirect_urls", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodGet)
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, "["+dummyRedirectURLJson+"]")
+	})
+
+	got, err := client.RedirectURLs().ListAll()
+
+	assert.Nil(t, err)
+	assert.Equal(t, got, []*RedirectURLResponse{&redirectURLResponse})
+}
+
+func TestRedirectURLService_ListAll_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	_, err := client.RedirectURLs().ListAll()
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
+func TestRedirectURLService_Delete_happyPath(t *testing.T) {
+	token := "token"
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	id := "some_id"
+	mux.HandleFunc("/redirect_urls/"+id, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodDelete)
+		testHeader(t, req, "Authorization", "Bearer "+token)
+
+		response := fmt.Sprintf(`{ "deleted": true, "id": "%v", "object": "user" }`, id)
+		fmt.Fprint(w, response)
+	})
+
+	got, err := client.RedirectURLs().Delete(id)
+	assert.Nil(t, err)
+	assert.NotNil(t, got)
+}
+
+func TestRedirectURLService_Delete_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	_, err := client.RedirectURLs().Delete("random_id")
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
+const dummyRedirectURLJson = `{
+    "object": "redirect_url",
+	"id": "ru_1mvFol71HiKCcypBd6xxg0IpMBN",
+	"url": "example.com"
+}`

--- a/tests/integration/redirect_urls_test.go
+++ b/tests/integration/redirect_urls_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/clerkinc/clerk-sdk-go/clerk"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedirectURLs(t *testing.T) {
+	client := createClient()
+
+	redirectURLs, err := client.RedirectURLs().ListAll()
+	assert.Nil(t, err)
+
+	previousRedirectURLsCount := len(redirectURLs)
+
+	url := fmt.Sprintf("http://www.%d.com", time.Now().Unix())
+	redirectURL, err := client.RedirectURLs().Create(clerk.CreateRedirectURLParams{
+		URL: url,
+	})
+	assert.Nil(t, err)
+	assert.NotEmpty(t, redirectURL.ID)
+	assert.Equal(t, url, redirectURL.URL)
+	assert.Equal(t, "redirect_url", redirectURL.Object)
+
+	redirectURLs, err = client.RedirectURLs().ListAll()
+	assert.Nil(t, err)
+	assert.Equal(t, previousRedirectURLsCount+1, len(redirectURLs))
+
+	deletedResponse, err := client.RedirectURLs().Delete(redirectURL.ID)
+	assert.Nil(t, err)
+	assert.Equal(t, redirectURL.ID, deletedResponse.ID)
+	assert.True(t, deletedResponse.Deleted)
+}


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This commit adds a new service `RedirectURLs` which exposes the following methods:
* _Create_: Creates a new redirect url
* _ListAll_: Retrieves a list of all available redirect urls
* _Delete_: Deletes the given redirect url

### Related Issue (optional)

<!--- Please link to the issue here: -->
