### PR TITLE
feat: Support setting the clerk_js_version param for instance updates

### DIFF
--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -28,6 +28,11 @@ type UpdateInstanceParams struct {
 	// If the empty string is provided, the support email that is currently
 	// configured in the instance will be removed.
 	SupportEmail *string `json:"support_email,omitempty"`
+
+	// ClerkJSVersion allows you to request a specific Clerk JS version on the Clerk Hosted Account pages.
+	// If an empty string is provided, the stored version will be removed.
+	// If an explicit version is not set, the Clerk JS version will be automatically be resolved.
+	ClerkJSVersion *string `json:"clerk_js_version,omitempty"`
 }
 
 func (s *InstanceService) Update(params UpdateInstanceParams) error {

--- a/clerk/instances_test.go
+++ b/clerk/instances_test.go
@@ -18,15 +18,17 @@ func TestInstanceService_Update_happyPath(t *testing.T) {
 
 	enabled := true
 	supportEmail := "support@clerk.dev"
+	clerkJSVersion := "42"
 	err := client.Instances().Update(UpdateInstanceParams{
 		TestMode:                    &enabled,
 		HIBP:                        &enabled,
 		EnhancedEmailDeliverability: &enabled,
 		SupportEmail:                &supportEmail,
+		ClerkJSVersion:              &clerkJSVersion,
 	})
 
 	if err != nil {
-		t.Errorf("expected no error to be return, found %v instead", err)
+		t.Errorf("expected no error to be returned, found %v instead", err)
 	}
 }
 
@@ -35,11 +37,13 @@ func TestInstanceService_Update_invalidServer(t *testing.T) {
 
 	enabled := true
 	supportEmail := "support@clerk.dev"
+	clerkJSVersion := "999"
 	err := client.Instances().Update(UpdateInstanceParams{
 		TestMode:                    &enabled,
 		HIBP:                        &enabled,
 		EnhancedEmailDeliverability: &enabled,
 		SupportEmail:                &supportEmail,
+		ClerkJSVersion:              &clerkJSVersion,
 	})
 	if err == nil {
 		t.Errorf("Expected error to be returned")


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

New `clerk_js_version` param support for the instance update operation.

If `""` is set, the value on the server will be cleared.

