### PR TITLE
feat: Added blocklists in Go SDK

### DIFF
--- a/clerk/blocklists.go
+++ b/clerk/blocklists.go
@@ -1,0 +1,57 @@
+package clerk
+
+import (
+	"net/http"
+)
+
+type BlocklistsService service
+
+type BlocklistIdentifierResponse struct {
+	Object     string `json:"object"`
+	ID         string `json:"id"`
+	Identifier string `json:"identifier"`
+	CreatedAt  int64  `json:"created_at"`
+	UpdatedAt  int64  `json:"updated_at"`
+}
+
+type CreateBlocklistIdentifierParams struct {
+	Identifier string `json:"identifier"`
+}
+
+func (s *BlocklistsService) CreateIdentifier(params CreateBlocklistIdentifierParams) (*BlocklistIdentifierResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodPost, BlocklistsUrl, &params)
+
+	var blocklistIdentifierResponse BlocklistIdentifierResponse
+	_, err := s.client.Do(req, &blocklistIdentifierResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &blocklistIdentifierResponse, nil
+}
+
+func (s *BlocklistsService) DeleteIdentifier(identifierID string) (*DeleteResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodDelete, BlocklistsUrl+"/"+identifierID)
+
+	var deleteResponse DeleteResponse
+	_, err := s.client.Do(req, &deleteResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &deleteResponse, nil
+}
+
+type BlocklistIdentifiersResponse struct {
+	Data       []*BlocklistIdentifierResponse `json:"data"`
+	TotalCount int64                          `json:"total_count"`
+}
+
+func (s *BlocklistsService) ListAllIdentifiers() (*BlocklistIdentifiersResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodGet, BlocklistsUrl)
+
+	var blocklistIdentifiersResponse *BlocklistIdentifiersResponse
+	_, err := s.client.Do(req, &blocklistIdentifiersResponse)
+	if err != nil {
+		return nil, err
+	}
+	return blocklistIdentifiersResponse, nil
+}

--- a/clerk/blocklists_test.go
+++ b/clerk/blocklists_test.go
@@ -1,0 +1,109 @@
+package clerk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlocklistService_CreateIdentifier_happyPath(t *testing.T) {
+	token := "token"
+	var blocklistIdentifier BlocklistIdentifierResponse
+	_ = json.Unmarshal([]byte(dummyBlocklistIdentifierJson), &blocklistIdentifier)
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	mux.HandleFunc("/blocklist_identifiers", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodPost)
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, dummyBlocklistIdentifierJson)
+	})
+
+	got, _ := client.Blocklists().CreateIdentifier(CreateBlocklistIdentifierParams{
+		Identifier: blocklistIdentifier.Identifier,
+	})
+
+	assert.Equal(t, &blocklistIdentifier, got)
+}
+
+func TestBlocklistService_CreateIdentifier_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	_, err := client.Blocklists().CreateIdentifier(CreateBlocklistIdentifierParams{
+		Identifier: "dummy@example.com",
+	})
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
+func TestBlocklistService_DeleteIdentifier_happyPath(t *testing.T) {
+	token := "token"
+	var blocklistIdentifier BlocklistIdentifierResponse
+	_ = json.Unmarshal([]byte(dummyBlocklistIdentifierJson), &blocklistIdentifier)
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	mux.HandleFunc("/blocklist_identifiers/"+blocklistIdentifier.ID, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodDelete)
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		response := fmt.Sprintf(`{ "deleted": true, "id": "%s", "object": "blocklist_identifier" }`, blocklistIdentifier.ID)
+		_, _ = fmt.Fprint(w, response)
+	})
+
+	got, _ := client.Blocklists().DeleteIdentifier(blocklistIdentifier.ID)
+	assert.Equal(t, blocklistIdentifier.ID, got.ID)
+	assert.True(t, got.Deleted)
+}
+
+func TestBlocklistService_DeleteIdentifier_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	_, err := client.Blocklists().DeleteIdentifier("blid_1mvFol71HiKCcypBd6xxg0IpMBN")
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
+func TestBlocklistService_ListAllIdentifiers_happyPath(t *testing.T) {
+	token := "token"
+	var blocklistIdentifier BlocklistIdentifierResponse
+	_ = json.Unmarshal([]byte(dummyBlocklistIdentifierJson), &blocklistIdentifier)
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	mux.HandleFunc("/blocklist_identifiers", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodGet)
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, fmt.Sprintf(`{"data": [%s], "total_count": 1}`, dummyBlocklistIdentifierJson))
+	})
+
+	got, _ := client.Blocklists().ListAllIdentifiers()
+
+	assert.Len(t, got.Data, 1)
+	assert.Equal(t, int64(1), got.TotalCount)
+	assert.Equal(t, &blocklistIdentifier, got.Data[0])
+}
+
+func TestBlocklistService_ListAllIdentifiers_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	_, err := client.Blocklists().ListAllIdentifiers()
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
+const dummyBlocklistIdentifierJson = `{
+    "id": "blid_1mvFol71HiKCcypBd6xxg0IpMBN",
+    "object": "blocklist_identifier",
+	"identifier": "dummy@example.com",
+	"created_at": 1610783813,
+	"updated_at": 1610783813
+}`

--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -18,6 +18,7 @@ const version = "1.14.0"
 const (
 	ProdUrl = "https://api.clerk.dev/v1/"
 
+	BlocklistsUrl    = "blocklist_identifiers"
 	ClientsUrl       = "clients"
 	ClientsVerifyUrl = ClientsUrl + "/verify"
 	EmailsUrl        = "emails"
@@ -41,6 +42,7 @@ type Client interface {
 	DecodeToken(token string) (*TokenClaims, error)
 	VerifyToken(token string, opts ...VerifyTokenOption) (*SessionClaims, error)
 
+	Blocklists() *BlocklistsService
 	Clients() *ClientsService
 	Emails() *EmailService
 	Instances() *InstanceService
@@ -69,6 +71,7 @@ type client struct {
 	jwksCache *jwksCache
 	token     string
 
+	blocklists    *BlocklistsService
 	clients       *ClientsService
 	emails        *EmailService
 	instances     *InstanceService
@@ -110,6 +113,7 @@ func NewClient(token string, options ...ClerkOption) (Client, error) {
 	}
 
 	commonService := &service{client: client}
+	client.blocklists = (*BlocklistsService)(commonService)
 	client.clients = (*ClientsService)(commonService)
 	client.emails = (*EmailService)(commonService)
 	client.instances = (*InstanceService)(commonService)
@@ -229,6 +233,10 @@ func checkForErrors(resp *http.Response) error {
 	}
 
 	return errorResponse
+}
+
+func (c *client) Blocklists() *BlocklistsService {
+	return c.blocklists
 }
 
 func (c *client) Clients() *ClientsService {

--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const version = "1.14.0"
+const version = "1.15.0"
 
 const (
 	ProdUrl = "https://api.clerk.dev/v1/"

--- a/tests/integration/blocklists_test.go
+++ b/tests/integration/blocklists_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/clerkinc/clerk-sdk-go/clerk"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlocklists(t *testing.T) {
+	client := createClient()
+
+	blocklistIdentifiers, err := client.Blocklists().ListAllIdentifiers()
+	assert.Nil(t, err)
+
+	previousCount := blocklistIdentifiers.TotalCount
+
+	identifier := fmt.Sprintf("email_%d@example.com", time.Now().Unix())
+	blocklistIdentifier, err := client.Blocklists().CreateIdentifier(clerk.CreateBlocklistIdentifierParams{
+		Identifier: identifier,
+	})
+	assert.Nil(t, err)
+	assert.NotEmpty(t, blocklistIdentifier.ID)
+	assert.Equal(t, identifier, blocklistIdentifier.Identifier)
+	assert.Equal(t, "blocklist_identifier", blocklistIdentifier.Object)
+
+	blocklistIdentifiers, err = client.Blocklists().ListAllIdentifiers()
+	assert.Nil(t, err)
+	assert.Equal(t, previousCount+1, blocklistIdentifiers.TotalCount)
+
+	deletedResponse, err := client.Blocklists().DeleteIdentifier(blocklistIdentifier.ID)
+	assert.Nil(t, err)
+	assert.Equal(t, blocklistIdentifier.ID, deletedResponse.ID)
+	assert.True(t, deletedResponse.Deleted)
+}


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This commit adds functions to handle blocklists.
In particular, it includes the following:
* `CreateIdentifier`: Creates a new blocklist identifier. This identifier can be an email address or domain, a phone number or a web3 wallet.
* `ListAllIdentifiers`: Returns all blocklist identifiers
* `DeleteIdentifier`: Deletes the blocklist identifier that corresponds to the given id

### Related Issue (optional)

<!--- Please link to the issue here: -->
