### PR TITLE
feat: Added allowlists in Go SDK

### DIFF
--- a/clerk/allowlists.go
+++ b/clerk/allowlists.go
@@ -1,0 +1,60 @@
+package clerk
+
+import "net/http"
+
+type AllowlistsService service
+
+type AllowlistIdentifierResponse struct {
+	Object       string `json:"object"`
+	ID           string `json:"id"`
+	InvitationID string `json:"invitation_id,omitempty"`
+	Identifier   string `json:"identifier"`
+	CreatedAt    int64  `json:"created_at"`
+	UpdatedAt    int64  `json:"updated_at"`
+}
+
+type CreateAllowlistIdentifierParams struct {
+	Identifier string `json:"identifier"`
+	Notify     bool   `json:"notify"`
+}
+
+func (s *AllowlistsService) CreateIdentifier(params CreateAllowlistIdentifierParams) (*AllowlistIdentifierResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodPost, AllowlistsUrl, &params)
+
+	var allowlistIdentifierResponse AllowlistIdentifierResponse
+	_, err := s.client.Do(req, &allowlistIdentifierResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &allowlistIdentifierResponse, nil
+}
+
+func (s *AllowlistsService) DeleteIdentifier(identifierID string) (*DeleteResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodDelete, AllowlistsUrl+"/"+identifierID)
+
+	var deleteResponse DeleteResponse
+	_, err := s.client.Do(req, &deleteResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &deleteResponse, nil
+}
+
+type AllowlistIdentifiersResponse struct {
+	Data       []*AllowlistIdentifierResponse `json:"data"`
+	TotalCount int64                          `json:"total_count"`
+}
+
+func (s *AllowlistsService) ListAllIdentifiers() (*AllowlistIdentifiersResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodGet, AllowlistsUrl)
+
+	var allowlistIdentifiersResponse []*AllowlistIdentifierResponse
+	_, err := s.client.Do(req, &allowlistIdentifiersResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &AllowlistIdentifiersResponse{
+		Data:       allowlistIdentifiersResponse,
+		TotalCount: int64(len(allowlistIdentifiersResponse)),
+	}, nil
+}

--- a/clerk/allowlists_test.go
+++ b/clerk/allowlists_test.go
@@ -1,0 +1,110 @@
+package clerk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllowlistService_CreateIdentifier_happyPath(t *testing.T) {
+	token := "token"
+	var allowlistIdentifier AllowlistIdentifierResponse
+	_ = json.Unmarshal([]byte(dummyAllowlistIdentifierJson), &allowlistIdentifier)
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	mux.HandleFunc("/allowlist_identifiers", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodPost)
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, dummyAllowlistIdentifierJson)
+	})
+
+	got, _ := client.Allowlists().CreateIdentifier(CreateAllowlistIdentifierParams{
+		Identifier: allowlistIdentifier.Identifier,
+	})
+
+	assert.Equal(t, &allowlistIdentifier, got)
+}
+
+func TestAllowlistService_CreateIdentifier_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	_, err := client.Allowlists().CreateIdentifier(CreateAllowlistIdentifierParams{
+		Identifier: "dummy@example.com",
+	})
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
+func TestAllowlistService_DeleteIdentifier_happyPath(t *testing.T) {
+	token := "token"
+	var allowlistIdentifier BlocklistIdentifierResponse
+	_ = json.Unmarshal([]byte(dummyBlocklistIdentifierJson), &allowlistIdentifier)
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	mux.HandleFunc("/allowlist_identifiers/"+allowlistIdentifier.ID, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodDelete)
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		response := fmt.Sprintf(`{ "deleted": true, "id": "%s", "object": "allowlist_identifier" }`, allowlistIdentifier.ID)
+		_, _ = fmt.Fprint(w, response)
+	})
+
+	got, _ := client.Allowlists().DeleteIdentifier(allowlistIdentifier.ID)
+	assert.Equal(t, allowlistIdentifier.ID, got.ID)
+	assert.True(t, got.Deleted)
+}
+
+func TestAllowlistService_DeleteIdentifier_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	_, err := client.Allowlists().DeleteIdentifier("alid_1mvFol71HiKCcypBd6xxg0IpMBN")
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
+func TestAllowlistService_ListAllIdentifiers_happyPath(t *testing.T) {
+	token := "token"
+	var allowlistIdentifier AllowlistIdentifierResponse
+	_ = json.Unmarshal([]byte(dummyAllowlistIdentifierJson), &allowlistIdentifier)
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	mux.HandleFunc("/allowlist_identifiers", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodGet)
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, fmt.Sprintf(`[%s]`, dummyAllowlistIdentifierJson))
+	})
+
+	got, _ := client.Allowlists().ListAllIdentifiers()
+
+	assert.Len(t, got.Data, 1)
+	assert.Equal(t, int64(1), got.TotalCount)
+	assert.Equal(t, &allowlistIdentifier, got.Data[0])
+}
+
+func TestAllowlistService_ListAllIdentifiers_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	_, err := client.Allowlists().ListAllIdentifiers()
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}
+
+const dummyAllowlistIdentifierJson = `{
+    "id": "alid_1mvFol71HiKCcypBd6xxg0IpMBN",
+    "object": "allowlist_identifier",
+	"identifier": "dummy@example.com",
+	"invitation_id": "inv_1mvFol71PeRCcypBd628g0IuRmF",
+	"created_at": 1610783813,
+	"updated_at": 1610783813
+}`

--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const version = "1.15.0"
+const version = "1.16.0"
 
 const (
 	ProdUrl = "https://api.clerk.dev/v1/"

--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -18,6 +18,7 @@ const version = "1.15.0"
 const (
 	ProdUrl = "https://api.clerk.dev/v1/"
 
+	AllowlistsUrl    = "allowlist_identifiers"
 	BlocklistsUrl    = "blocklist_identifiers"
 	ClientsUrl       = "clients"
 	ClientsVerifyUrl = ClientsUrl + "/verify"
@@ -42,6 +43,7 @@ type Client interface {
 	DecodeToken(token string) (*TokenClaims, error)
 	VerifyToken(token string, opts ...VerifyTokenOption) (*SessionClaims, error)
 
+	Allowlists() *AllowlistsService
 	Blocklists() *BlocklistsService
 	Clients() *ClientsService
 	Emails() *EmailService
@@ -71,6 +73,7 @@ type client struct {
 	jwksCache *jwksCache
 	token     string
 
+	allowlists    *AllowlistsService
 	blocklists    *BlocklistsService
 	clients       *ClientsService
 	emails        *EmailService
@@ -113,6 +116,7 @@ func NewClient(token string, options ...ClerkOption) (Client, error) {
 	}
 
 	commonService := &service{client: client}
+	client.allowlists = (*AllowlistsService)(commonService)
 	client.blocklists = (*BlocklistsService)(commonService)
 	client.clients = (*ClientsService)(commonService)
 	client.emails = (*EmailService)(commonService)
@@ -233,6 +237,10 @@ func checkForErrors(resp *http.Response) error {
 	}
 
 	return errorResponse
+}
+
+func (c *client) Allowlists() *AllowlistsService {
+	return c.allowlists
 }
 
 func (c *client) Blocklists() *BlocklistsService {

--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -41,3 +41,25 @@ func (s *InstanceService) Update(params UpdateInstanceParams) error {
 	_, err := s.client.Do(req, nil)
 	return err
 }
+
+type InstanceRestrictionsResponse struct {
+	Object    string `json:"object"`
+	Allowlist bool   `json:"allowlist"`
+	Blocklist bool   `json:"blocklist"`
+}
+
+type UpdateRestrictionsParams struct {
+	Allowlist *bool `json:"allowlist"`
+	Blocklist *bool `json:"blocklist"`
+}
+
+func (s *InstanceService) UpdateRestrictions(params UpdateRestrictionsParams) (*InstanceRestrictionsResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodPatch, "instance/restrictions", &params)
+
+	var instanceRestrictionsResponse InstanceRestrictionsResponse
+	_, err := s.client.Do(req, &instanceRestrictionsResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &instanceRestrictionsResponse, nil
+}

--- a/clerk/organizations.go
+++ b/clerk/organizations.go
@@ -14,7 +14,7 @@ type Organization struct {
 	Name            string          `json:"name"`
 	Slug            *string         `json:"slug"`
 	LogoURL         *string         `json:"logo_url"`
-	MembersCount    int             `json:"members_count,omitempty"`
+	MembersCount    *int            `json:"members_count,omitempty"`
 	PublicMetadata  json.RawMessage `json:"public_metadata"`
 	PrivateMetadata json.RawMessage `json:"private_metadata,omitempty"`
 	CreatedAt       int64           `json:"created_at"`

--- a/tests/integration/allowlists_test.go
+++ b/tests/integration/allowlists_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/clerkinc/clerk-sdk-go/clerk"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllowlists(t *testing.T) {
+	client := createClient()
+
+	allowlistIdentifiers, err := client.Allowlists().ListAllIdentifiers()
+	assert.Nil(t, err)
+
+	previousCount := allowlistIdentifiers.TotalCount
+
+	identifier := fmt.Sprintf("email_%d@example.com", time.Now().Unix())
+	allowlistIdentifier, err := client.Allowlists().CreateIdentifier(clerk.CreateAllowlistIdentifierParams{
+		Identifier: identifier,
+	})
+	assert.Nil(t, err)
+	assert.NotEmpty(t, allowlistIdentifier.ID)
+	assert.Equal(t, identifier, allowlistIdentifier.Identifier)
+	assert.Equal(t, "allowlist_identifier", allowlistIdentifier.Object)
+
+	allowlistIdentifiers, err = client.Allowlists().ListAllIdentifiers()
+	assert.Nil(t, err)
+	assert.Equal(t, previousCount+1, allowlistIdentifiers.TotalCount)
+
+	deletedResponse, err := client.Allowlists().DeleteIdentifier(allowlistIdentifier.ID)
+	assert.Nil(t, err)
+	assert.Equal(t, allowlistIdentifier.ID, deletedResponse.ID)
+	assert.True(t, deletedResponse.Deleted)
+}

--- a/tests/integration/instances_test.go
+++ b/tests/integration/instances_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/clerkinc/clerk-sdk-go/clerk"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInstances(t *testing.T) {
@@ -23,4 +24,17 @@ func TestInstances(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Instances.Update returned error: %v", err)
 	}
+}
+
+func TestInstanceRestrictions(t *testing.T) {
+	client := createClient()
+
+	enabled := true
+	restrictionsResponse, err := client.Instances().UpdateRestrictions(clerk.UpdateRestrictionsParams{
+		Allowlist: &enabled,
+		Blocklist: &enabled,
+	})
+	assert.Nil(t, err)
+	assert.True(t, restrictionsResponse.Allowlist)
+	assert.True(t, restrictionsResponse.Blocklist)
 }

--- a/tests/integration/organizations_test.go
+++ b/tests/integration/organizations_test.go
@@ -26,6 +26,6 @@ func TestOrganizations(t *testing.T) {
 	assert.Greater(t, len(organizations.Data), 0)
 	assert.Greater(t, organizations.TotalCount, int64(0))
 	for _, organization := range organizations.Data {
-		assert.Greater(t, organization.MembersCount, 0)
+		assert.Greater(t, *organization.MembersCount, 0)
 	}
 }


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This commit adds functions to handle allowlists.
In particular, it includes the following:
* `CreateIdentifier`: Creates a new allowlist identifier. This identifier can be an email address or domain, a phone number or a web3 wallet.
* `ListAllIdentifiers`: Returns all allowlist identifiers
* `DeleteIdentifier`: Deletes the allowlist identifier that corresponds to the given id

### Related Issue (optional)

<!--- Please link to the issue here: -->
