### PR TITLE
feat: Added method on instance service to update organization settings

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const version = "1.22.0"
+const version = "1.23.0"
 
 const (
 	ProdUrl = "https://api.clerk.dev/v1/"

--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -63,3 +63,23 @@ func (s *InstanceService) UpdateRestrictions(params UpdateRestrictionsParams) (*
 	}
 	return &instanceRestrictionsResponse, nil
 }
+
+type OrganizationSettingsResponse struct {
+	Object  string `json:"object"`
+	Enabled bool   `json:"enabled"`
+}
+
+type UpdateOrganizationSettingsParams struct {
+	Enabled *bool `json:"enabled"`
+}
+
+func (s *InstanceService) UpdateOrganizationSettings(params UpdateOrganizationSettingsParams) (*OrganizationSettingsResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodPatch, "instance/organization_settings", &params)
+
+	var organizationSettingsResponse OrganizationSettingsResponse
+	_, err := s.client.Do(req, &organizationSettingsResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &organizationSettingsResponse, nil
+}

--- a/clerk/instances_test.go
+++ b/clerk/instances_test.go
@@ -93,3 +93,40 @@ func TestInstanceService_UpdateRestrictions_invalidServer(t *testing.T) {
 		t.Errorf("Expected error to be returned")
 	}
 }
+
+func TestInstanceService_UpdateOrganizationSettings_happyPath(t *testing.T) {
+	token := "token"
+	dummyOrganizationSettingsResponseJSON := `{
+		"enabled": true
+	}`
+	var organizationSettingsResponse OrganizationSettingsResponse
+	_ = json.Unmarshal([]byte(dummyOrganizationSettingsResponseJSON), &organizationSettingsResponse)
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	mux.HandleFunc("/instance/organization_settings", func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, http.MethodPatch)
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, dummyOrganizationSettingsResponseJSON)
+	})
+
+	enabled := true
+	got, _ := client.Instances().UpdateOrganizationSettings(UpdateOrganizationSettingsParams{
+		Enabled: &enabled,
+	})
+
+	assert.Equal(t, &organizationSettingsResponse, got)
+}
+
+func TestInstanceService_UpdateOrganizationSettings_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+
+	enabled := true
+	_, err := client.Instances().UpdateOrganizationSettings(UpdateOrganizationSettingsParams{
+		Enabled: &enabled,
+	})
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
+}

--- a/tests/integration/instances_test.go
+++ b/tests/integration/instances_test.go
@@ -38,3 +38,14 @@ func TestInstanceRestrictions(t *testing.T) {
 	assert.True(t, restrictionsResponse.Allowlist)
 	assert.True(t, restrictionsResponse.Blocklist)
 }
+
+func TestInstanceOrganizationSettings(t *testing.T) {
+	client := createClient()
+
+	enabled := true
+	organizationSettingsResponse, err := client.Instances().UpdateOrganizationSettings(clerk.UpdateOrganizationSettingsParams{
+		Enabled: &enabled,
+	})
+	assert.Nil(t, err)
+	assert.True(t, organizationSettingsResponse.Enabled)
+}


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Added new method on instance service `UpdateOrganizationSettings` which allows users to update the instance's organization settings.

### Related Issue (optional)

<!--- Please link to the issue here: -->
