### PR TITLE
Added methods for creating, updating and deleting organizations

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const version = "1.24.0"
+const version = "1.25.0"
 
 const (
 	ProdUrl = "https://api.clerk.dev/v1/"

--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -65,12 +65,14 @@ func (s *InstanceService) UpdateRestrictions(params UpdateRestrictionsParams) (*
 }
 
 type OrganizationSettingsResponse struct {
-	Object  string `json:"object"`
-	Enabled bool   `json:"enabled"`
+	Object                string `json:"object"`
+	Enabled               bool   `json:"enabled"`
+	MaxAllowedMemberships int    `json:"max_allowed_memberships"`
 }
 
 type UpdateOrganizationSettingsParams struct {
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled               *bool `json:"enabled,omitempty"`
+	MaxAllowedMemberships *int  `json:"max_allowed_memberships,omitempty"`
 }
 
 func (s *InstanceService) UpdateOrganizationSettings(params UpdateOrganizationSettingsParams) (*OrganizationSettingsResponse, error) {

--- a/clerk/instances_test.go
+++ b/clerk/instances_test.go
@@ -97,7 +97,8 @@ func TestInstanceService_UpdateRestrictions_invalidServer(t *testing.T) {
 func TestInstanceService_UpdateOrganizationSettings_happyPath(t *testing.T) {
 	token := "token"
 	dummyOrganizationSettingsResponseJSON := `{
-		"enabled": true
+		"enabled": true,
+		"max_allowed_memberships": 2
 	}`
 	var organizationSettingsResponse OrganizationSettingsResponse
 	_ = json.Unmarshal([]byte(dummyOrganizationSettingsResponseJSON), &organizationSettingsResponse)

--- a/clerk/organizations.go
+++ b/clerk/organizations.go
@@ -2,6 +2,7 @@ package clerk
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 )
@@ -9,16 +10,64 @@ import (
 type OrganizationsService service
 
 type Organization struct {
-	Object          string          `json:"object"`
-	ID              string          `json:"id"`
-	Name            string          `json:"name"`
-	Slug            *string         `json:"slug"`
-	LogoURL         *string         `json:"logo_url"`
-	MembersCount    *int            `json:"members_count,omitempty"`
-	PublicMetadata  json.RawMessage `json:"public_metadata"`
-	PrivateMetadata json.RawMessage `json:"private_metadata,omitempty"`
-	CreatedAt       int64           `json:"created_at"`
-	UpdatedAt       int64           `json:"updated_at"`
+	Object                string          `json:"object"`
+	ID                    string          `json:"id"`
+	Name                  string          `json:"name"`
+	Slug                  *string         `json:"slug"`
+	LogoURL               *string         `json:"logo_url"`
+	MembersCount          *int            `json:"members_count,omitempty"`
+	MaxAllowedMemberships int             `json:"max_allowed_memberships"`
+	PublicMetadata        json.RawMessage `json:"public_metadata"`
+	PrivateMetadata       json.RawMessage `json:"private_metadata,omitempty"`
+	CreatedAt             int64           `json:"created_at"`
+	UpdatedAt             int64           `json:"updated_at"`
+}
+
+type CreateOrganizationParams struct {
+	Name                  string          `json:"name"`
+	Slug                  *string         `json:"slug,omitempty"`
+	CreatedBy             string          `json:"created_by"`
+	MaxAllowedMemberships *int            `json:"max_allowed_memberships,omitempty"`
+	PublicMetadata        json.RawMessage `json:"public_metadata,omitempty"`
+	PrivateMetadata       json.RawMessage `json:"private_metadata,omitempty"`
+}
+
+func (s *OrganizationsService) Create(params CreateOrganizationParams) (*Organization, error) {
+	req, _ := s.client.NewRequest(http.MethodPost, OrganizationsUrl, &params)
+
+	var organization Organization
+	_, err := s.client.Do(req, &organization)
+	if err != nil {
+		return nil, err
+	}
+	return &organization, nil
+}
+
+type UpdateOrganizationParams struct {
+	Name                  *string `json:"name,omitempty"`
+	MaxAllowedMemberships *int    `json:"max_allowed_memberships,omitempty"`
+}
+
+func (s *OrganizationsService) Update(organizationID string, params UpdateOrganizationParams) (*Organization, error) {
+	req, _ := s.client.NewRequest(http.MethodPatch, fmt.Sprintf("%s/%s", OrganizationsUrl, organizationID), &params)
+
+	var organization Organization
+	_, err := s.client.Do(req, &organization)
+	if err != nil {
+		return nil, err
+	}
+	return &organization, nil
+}
+
+func (s *OrganizationsService) Delete(organizationID string) (*DeleteResponse, error) {
+	req, _ := s.client.NewRequest(http.MethodDelete, fmt.Sprintf("%s/%s", OrganizationsUrl, organizationID))
+
+	var deleteResponse DeleteResponse
+	_, err := s.client.Do(req, &deleteResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &deleteResponse, nil
 }
 
 type OrganizationsResponse struct {

--- a/tests/integration/instances_test.go
+++ b/tests/integration/instances_test.go
@@ -43,8 +43,10 @@ func TestInstanceOrganizationSettings(t *testing.T) {
 	client := createClient()
 
 	enabled := true
+	allowedMemberships := 0
 	organizationSettingsResponse, err := client.Instances().UpdateOrganizationSettings(clerk.UpdateOrganizationSettingsParams{
-		Enabled: &enabled,
+		Enabled:               &enabled,
+		MaxAllowedMemberships: &allowedMemberships,
 	})
 	assert.Nil(t, err)
 	assert.True(t, organizationSettingsResponse.Enabled)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This PR adds three new methods in the organizations service, to create, update and delete organizations.

It also allows users to configure the max allowed memberships on the instance level.

### Related Issue (optional)

<!--- Please link to the issue here: -->
