### PR TITLE
feat: Add support for updating user's TOTP secret and backup codes

### DIFF
--- a/clerk/users.go
+++ b/clerk/users.go
@@ -70,6 +70,7 @@ type CreateUserParams struct {
 	PublicMetadata  *json.RawMessage `json:"public_metadata,omitempty"`
 	PrivateMetadata *json.RawMessage `json:"private_metadata,omitempty"`
 	TOTPSecret      *string          `json:"totp_secret,omitempty"`
+	BackupCodes     []string         `json:"backup_codes,omitempty"`
 }
 
 func (s *UsersService) Create(params CreateUserParams) (*User, error) {
@@ -203,6 +204,8 @@ type UpdateUser struct {
 	PublicMetadata        interface{} `json:"public_metadata,omitempty"`
 	PrivateMetadata       interface{} `json:"private_metadata,omitempty"`
 	UnsafeMetadata        interface{} `json:"unsafe_metadata,omitempty"`
+	TOTPSecret            *string     `json:"totp_secret,omitempty"`
+	BackupCodes           []string    `json:"backup_codes,omitempty"`
 }
 
 func (s *UsersService) Update(userId string, updateRequest *UpdateUser) (*User, error) {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Add support for updating user's TOTP secret and backup codes
Also included the missing parameter for backup codes in create user endpoint

### Related Issue (optional)

<!--- Please link to the issue here: -->

https://www.notion.so/clerkdev/Allow-updating-totp_secret-backup_codes-for-a-user-via-BAPI-77ed76eeed3d4681b54f04e2ae566016
