### PR TITLE
feat: Add support for sign_up read & update operations

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -30,6 +30,7 @@ const (
 	PhoneNumbersURL   = "phone_numbers"
 	RedirectURLsUrl   = "redirect_urls"
 	SessionsUrl       = "sessions"
+	SignUpsURL        = "sign_ups"
 	SMSUrl            = "sms_messages"
 	TemplatesUrl      = "templates"
 	UsersUrl          = "users"
@@ -60,6 +61,7 @@ type Client interface {
 	PhoneNumbers() *PhoneNumbersService
 	RedirectURLs() *RedirectURLsService
 	Sessions() *SessionsService
+	SignUps() *SignUpService
 	SMS() *SMSService
 	Templates() *TemplatesService
 	Users() *UsersService
@@ -93,6 +95,7 @@ type client struct {
 	phoneNumbers   *PhoneNumbersService
 	redirectURLs   *RedirectURLsService
 	sessions       *SessionsService
+	signUps        *SignUpService
 	sms            *SMSService
 	templates      *TemplatesService
 	users          *UsersService
@@ -139,6 +142,7 @@ func NewClient(token string, options ...ClerkOption) (Client, error) {
 	client.phoneNumbers = (*PhoneNumbersService)(commonService)
 	client.redirectURLs = (*RedirectURLsService)(commonService)
 	client.sessions = (*SessionsService)(commonService)
+	client.signUps = (*SignUpService)(commonService)
 	client.sms = (*SMSService)(commonService)
 	client.templates = (*TemplatesService)(commonService)
 	client.users = (*UsersService)(commonService)
@@ -302,6 +306,10 @@ func (c *client) RedirectURLs() *RedirectURLsService {
 
 func (c *client) Sessions() *SessionsService {
 	return c.sessions
+}
+
+func (c *client) SignUps() *SignUpService {
+	return c.signUps
 }
 
 func (c *client) SMS() *SMSService {

--- a/clerk/phone_numbers_test.go
+++ b/clerk/phone_numbers_test.go
@@ -3,10 +3,11 @@ package clerk
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPhoneNumbersService_Create_HappyPath(t *testing.T) {
@@ -109,7 +110,7 @@ func TestPhoneNumbersService_Update_HappyPath(t *testing.T) {
 
 func TestPhoneNumbersService_Delete_HappyPath(t *testing.T) {
 	token := "token"
-	phoneNumberID := "idn_banana"
+	phoneNumberID := "idn_avocado"
 
 	client, mux, _, teardown := setup(token)
 	defer teardown()

--- a/clerk/sign_ups.go
+++ b/clerk/sign_ups.go
@@ -1,0 +1,87 @@
+package clerk
+
+import "fmt"
+
+type SignUpService service
+
+type SignUp struct {
+	Object           string              `json:"object"`
+	ID               string              `json:"id"`
+	Status           string              `json:"status"`
+	RequiredFields   []string            `json:"required_fields"`
+	OptionalFields   []string            `json:"optional_fields"`
+	MissingFields    []string            `json:"missing_fields"`
+	UnverifiedFields []string            `json:"unverified_fields"`
+	Verifications    SignUpVerifications `json:"verifications"`
+
+	Username     *string `json:"username"`
+	EmailAddress *string `json:"email_address"`
+	PhoneNumber  *string `json:"phone_number"`
+	Web3Wallet   *string `json:"web3_wallet"`
+
+	PasswordEnabled  bool        `json:"password_enabled"`
+	FirstName        *string     `json:"first_name"`
+	LastName         *string     `json:"last_name"`
+	UnsafeMetadata   interface{} `json:"unsafe_metadata,omitempty"`
+	PublicMetadata   interface{} `json:"public_metadata,omitempty"`
+	CustomAction     bool        `json:"custom_action"`
+	ExternalID       *string     `json:"external_id"`
+	CreatedSessionID *string     `json:"created_session_id"`
+	CreatedUserID    *string     `json:"created_user_id"`
+	AbandonAt        int64       `json:"abandon_at"`
+
+	IdentificationRequirements  [][]string    `json:"identification_requirements"`   // DX: Deprecated
+	MissingRequirements         []string      `json:"missing_requirements"`          // DX: Deprecated
+	EmailAddressVerification    *Verification `json:"email_address_verification"`    // DX: Deprecated
+	PhoneNumberVerification     *Verification `json:"phone_number_verification"`     // DX: Deprecated
+	ExternalAccountStrategy     *string       `json:"external_account_strategy"`     // DX: Deprecated
+	ExternalAccountVerification *Verification `json:"external_account_verification"` // DX: Deprecated
+	ExternalAccount             interface{}   `json:"external_account,omitempty"`    // DX: Deprecated
+}
+
+type SignUpVerifications struct {
+	EmailAddress    *signUpVerification `json:"email_address"`
+	PhoneNumber     *signUpVerification `json:"phone_number"`
+	Web3Wallet      *signUpVerification `json:"web3_wallet"`
+	ExternalAccount *Verification       `json:"external_account"`
+}
+
+type signUpVerification struct {
+	*Verification
+	NextAction          string   `json:"next_action"`
+	SupportedStrategies []string `json:"supported_strategies"`
+}
+
+func (s *SignUpService) Read(signUpID string) (*SignUp, error) {
+	signUpURL := fmt.Sprintf("%s/%s", SignUpsURL, signUpID)
+	req, _ := s.client.NewRequest("GET", signUpURL)
+
+	var signUp SignUp
+
+	_, err := s.client.Do(req, &signUp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &signUp, nil
+}
+
+// FIXME how to define "not set" semantics for external_id?
+type UpdateSignUp struct {
+	CustomAction *bool   `json:"custom_action" form:"custom_action"`
+	ExternalID   *string `json:"external_id" form:"external_id"`
+}
+
+func (s *SignUpService) Update(signUpID string, updateRequest *UpdateSignUp) (*SignUp, error) {
+	signUpURL := fmt.Sprintf("%s/%s", SignUpsURL, signUpID)
+	req, _ := s.client.NewRequest("PATCH", signUpURL, updateRequest)
+
+	var signUp SignUp
+
+	_, err := s.client.Do(req, &signUp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &signUp, nil
+}

--- a/clerk/sign_ups_test.go
+++ b/clerk/sign_ups_test.go
@@ -1,0 +1,110 @@
+package clerk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestSignUpService_Read_HappyPath(t *testing.T) {
+	token := "token"
+	signUpID := "someSignUpID"
+	expectedResponse := dummySignUpJSON
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	mux.HandleFunc("/sign_ups/"+signUpID, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, "GET")
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, expectedResponse)
+	})
+
+	var want SignUp
+	_ = json.Unmarshal([]byte(expectedResponse), &want)
+
+	got, _ := client.SignUps().Read(signUpID)
+	if !reflect.DeepEqual(*got, want) {
+		t.Errorf("Response = %v, want %v", *got, want)
+	}
+}
+
+func TestSignUpService_Update_HappyPath(t *testing.T) {
+	token := "token"
+	signUpID := "someSignUpID"
+
+	customAction := true
+	externalID := "eternia"
+	payload := UpdateSignUp{
+		CustomAction: &customAction,
+		ExternalID:   &externalID,
+	}
+
+	client, mux, _, teardown := setup(token)
+	defer teardown()
+
+	mux.HandleFunc("/sign_ups/"+signUpID, func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, "PATCH")
+		testHeader(t, req, "Authorization", "Bearer "+token)
+		fmt.Fprint(w, dummySignUpJSON)
+	})
+
+	got, _ := client.SignUps().Update(signUpID, &payload)
+
+	var want SignUp
+	_ = json.Unmarshal([]byte(dummySignUpJSON), &want)
+
+	if !reflect.DeepEqual(*got, want) {
+		t.Errorf("Response = %v, want %v", *got, payload)
+	}
+}
+
+const dummySignUpJSON = `{
+	"object": "sign_up_attempt",
+	"id": "sua_ekekekekekekek",
+	"status": "missing_requirements",
+	"required_fields": [
+		"email_address",
+		"password"
+	],
+	"optional_fields": [],
+	"missing_fields": [
+		"email_address",
+		"password"
+	],
+	"unverified_fields": [],
+	"verifications": {
+		"email_address": null,
+		"phone_number": null,
+		"web3_wallet": null,
+		"external_account": null
+	},
+	"username": null,
+	"email_address": null,
+	"phone_number": null,
+	"web3_wallet": null,
+	"password_enabled": false,
+	"first_name": null,
+	"last_name": null,
+	"unsafe_metadata": {},
+	"public_metadata": {},
+	"custom_action": false,
+	"external_id": null,
+	"created_session_id": null,
+	"created_user_id": null,
+	"abandon_at": 449971200000,
+	"identification_requirements": [
+		["email_address"],
+		[]
+	],
+	"missing_requirements": [
+		"password",
+		"email_address"
+	],
+	"email_address_verification": null,
+	"phone_number_verification": null,
+	"external_account_strategy": null,
+	"external_account_verification": null
+}`

--- a/tests/integration/sign_ups_test.go
+++ b/tests/integration/sign_ups_test.go
@@ -1,0 +1,17 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"testing"
+)
+
+func TestSignUps(t *testing.T) {
+	t.Skip()
+	//client := createClient()
+
+	// read
+
+	// TODO determine how to obtain a reference to a sign-up
+}


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Add support for:

* Reading a sign-up by ID
* Updating a sign-up by ID (supported params: `custom_action` & `external_id`)
