### PR TITLE
feat: Support new issuer format for dev instances

### DIFF
--- a/clerk/middleware.go
+++ b/clerk/middleware.go
@@ -51,7 +51,7 @@ func isAuthV2Request(r *http.Request, client Client) (string, bool) {
 
 	claims, err := client.DecodeToken(headerToken)
 	if err == nil {
-		return headerToken, strings.HasPrefix(claims.Issuer, "https://clerk.")
+		return headerToken, isValidIssuer(claims.Issuer)
 	}
 
 	// Verification from header token failed, try with token from cookie
@@ -65,5 +65,5 @@ func isAuthV2Request(r *http.Request, client Client) (string, bool) {
 		return "", false
 	}
 
-	return cookieSession.Value, strings.HasPrefix(claims.Issuer, "https://clerk.")
+	return cookieSession.Value, isValidIssuer(claims.Issuer)
 }

--- a/clerk/tokens.go
+++ b/clerk/tokens.go
@@ -100,7 +100,7 @@ func (c *client) VerifyToken(token string, opts ...VerifyTokenOption) (*SessionC
 		return nil, err
 	}
 
-	if !strings.HasPrefix(claims.Issuer, "https://clerk.") {
+	if !isValidIssuer(claims.Issuer) {
 		return nil, fmt.Errorf("invalid issuer %s", claims.Issuer)
 	}
 
@@ -131,4 +131,8 @@ func verifyTokenParseClaims(parsedToken *jwt.JSONWebToken, key interface{}, sess
 		return parsedToken.Claims(key, sessionClaims)
 	}
 	return parsedToken.Claims(key, sessionClaims, options.customClaims)
+}
+
+func isValidIssuer(issuer string) bool {
+	return strings.HasPrefix(issuer, "https://clerk.") || strings.Contains(issuer, ".clerk.accounts")
 }

--- a/clerk/tokens_test.go
+++ b/clerk/tokens_test.go
@@ -198,6 +198,27 @@ func TestClient_VerifyToken_Success(t *testing.T) {
 	}
 }
 
+func TestClient_VerifyToken_Success_NewIssuerFormat(t *testing.T) {
+	c, _ := NewClient("token")
+
+	claims := dummySessionClaims
+	claims.Issuer = "https://foo-bar-13.clerk.accounts.dev"
+
+	token, pubKey := testGenerateTokenJWT(t, dummySessionClaims, "kid")
+
+	client := c.(*client)
+	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS256, "kid"))
+
+	got, err := c.VerifyToken(token)
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	if !reflect.DeepEqual(got, &dummySessionClaims) {
+		t.Errorf("Expected %+v, but got %+v", dummySessionClaims, got)
+	}
+}
+
 func TestClient_VerifyToken_Success_ExpiredCache(t *testing.T) {
 	c, mux, _, teardown := setup("token")
 	defer teardown()


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This commit adds support for the new issuer format we are going to introduce for our dev instances. The new format is `https://foo-bar-13.clerk.accounts.dev` when the old one would be `https://clerk.foo.bar-13.lcl.dev`

### Related Issue (optional)

<!--- Please link to the issue here: -->
