### PR TITLE
feat: Allow organizations update to receive metadata

### DIFF
--- a/clerk/organizations.go
+++ b/clerk/organizations.go
@@ -44,8 +44,10 @@ func (s *OrganizationsService) Create(params CreateOrganizationParams) (*Organiz
 }
 
 type UpdateOrganizationParams struct {
-	Name                  *string `json:"name,omitempty"`
-	MaxAllowedMemberships *int    `json:"max_allowed_memberships,omitempty"`
+	Name                  *string         `json:"name,omitempty"`
+	MaxAllowedMemberships *int            `json:"max_allowed_memberships,omitempty"`
+	PublicMetadata        json.RawMessage `json:"public_metadata,omitempty"`
+	PrivateMetadata       json.RawMessage `json:"private_metadata,omitempty"`
 }
 
 func (s *OrganizationsService) Update(organizationID string, params UpdateOrganizationParams) (*Organization, error) {

--- a/clerk/organizations_test.go
+++ b/clerk/organizations_test.go
@@ -38,7 +38,48 @@ func TestOrganizationsService_Read(t *testing.T) {
 	if !reflect.DeepEqual(got, &want) {
 		t.Errorf("Response = %v, want %v", got, &want)
 	}
+}
 
+func TestOrganizationsService_Update(t *testing.T) {
+	client, mux, _, teardown := setup("token")
+	defer teardown()
+	var payload UpdateOrganizationParams
+	_ = json.Unmarshal([]byte(dummyUpdateOrganizationJson), &payload)
+
+	expectedResponse := dummyOrganizationJson
+	orgID := "randomIDorSlug"
+
+	mux.HandleFunc(fmt.Sprintf("/organizations/%s", orgID), func(w http.ResponseWriter, req *http.Request) {
+		testHttpMethod(t, req, "PATCH")
+		testHeader(t, req, "Authorization", "Bearer token")
+		fmt.Fprint(w, expectedResponse)
+	})
+
+	got, err := client.Organizations().Update(orgID, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var want Organization
+	err = json.Unmarshal([]byte(expectedResponse), &want)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Response = %v, want %v", got, &want)
+	}
+}
+
+func TestOrganizationsService_invalidServer(t *testing.T) {
+	client, _ := NewClient("token")
+	var payload UpdateOrganizationParams
+	_ = json.Unmarshal([]byte(dummyUpdateOrganizationJson), &payload)
+
+	_, err := client.Organizations().Update("someOrgId", payload)
+	if err == nil {
+		t.Errorf("Expected error to be returned")
+	}
 }
 
 func TestOrganizationsService_ListAll_happyPath(t *testing.T) {
@@ -139,5 +180,19 @@ const dummyOrganizationJson = `{
 		},
 		"private_metadata": {
 			"app_id": 5
+		}
+    }`
+
+const dummyUpdateOrganizationJson = `{
+        "object": "organization",
+        "id": "org_1mebQggrD3xO5JfuHk7clQ94ysA",
+        "name": "test-org",
+        "slug": "org_slug",
+		"members_count": 42,
+        "created_at": 1610783813,
+        "updated_at": 1610783813,
+		"public_metadata": {},
+		"private_metadata": {
+			"app_id": 8,
 		}
     }`


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

The UpdateMetadata function is only allow us to append or modify the params, the deletions can be done only by setting the value of a property to null. This adds extra complexity to the front end in order to perform deletion. We modify the Update organizations function in order to receive metadata so we will be able to delete easier.

