### PR TITLE
chore: Add test for organization metadata

### DIFF
--- a/tests/integration/organizations_test.go
+++ b/tests/integration/organizations_test.go
@@ -4,11 +4,16 @@
 package integration
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/clerkinc/clerk-sdk-go/clerk"
 	"github.com/stretchr/testify/assert"
 )
+
+type organizationMetadata struct {
+	AppID int `json:"app_id"`
+}
 
 func TestOrganizations(t *testing.T) {
 	client := createClient()
@@ -42,6 +47,26 @@ func TestOrganizations(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, membershipLimit, updatedOrganization.MaxAllowedMemberships)
+
+	privateMetadata, err := json.Marshal(
+		organizationMetadata{
+			AppID: 6,
+		},
+	)
+	publicMetadata, err := json.Marshal(
+		organizationMetadata{
+			AppID: 2,
+		},
+	)
+	updatedOrganization, err = client.Organizations().Update(newOrganization.ID, clerk.UpdateOrganizationParams{
+		PrivateMetadata: privateMetadata,
+		PublicMetadata:  publicMetadata,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, updatedOrganization.PrivateMetadata, json.RawMessage(privateMetadata))
+	assert.Equal(t, updatedOrganization.PublicMetadata, json.RawMessage(publicMetadata))
 
 	organizations, err := client.Organizations().ListAll(clerk.ListAllOrganizationsParams{
 		IncludeMembersCount: true,


### PR DESCRIPTION

## Type of change

Only changes on the `organizations_test.go`

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

We added some test cases to check if we can correctly update the organization metadata through the update function.


