### PR TITLE
chore: Deprecate cookieless_dev setting

### DIFF
--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -37,6 +37,8 @@ type UpdateInstanceParams struct {
 	// CookielessDev can be used to enable the new mode in which no third-party
 	// cookies are used in development instances. Make sure to also enable the
 	// setting in Clerk.js
+	//
+	// Deprecated: Use URLBasedSessionSyncing instead
 	CookielessDev *bool `json:"cookieless_dev,omitempty"`
 
 	// URLBasedSessionSyncing can be used to enable the new mode in which no third-party


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [x] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Now that dashboard has switched to using the `url_based_session_syncing` setting, marking `cookieless_dev` as deprecated.
