### PR TITLE
chore: Add UserID as filter param at organizations

### DIFF
--- a/clerk/organizations.go
+++ b/clerk/organizations.go
@@ -110,6 +110,7 @@ type ListAllOrganizationsParams struct {
 	Offset              *int
 	IncludeMembersCount bool
 	Query               string
+	UserIDs             []string
 }
 
 func (s *OrganizationsService) ListAll(params ListAllOrganizationsParams) (*OrganizationsResponse, error) {
@@ -127,6 +128,9 @@ func (s *OrganizationsService) ListAll(params ListAllOrganizationsParams) (*Orga
 	}
 	if params.Query != "" {
 		query.Add("query", params.Query)
+	}
+	for _, userID := range params.UserIDs {
+		query.Add("user_id", userID)
 	}
 	req.URL.RawQuery = query.Encode()
 


### PR DESCRIPTION
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

By adding UserID as param at ListAll organizations we can exclude or include this userID from the query. 
