### PR TITLE
fix: Change UpdateUserMetadata to proper type

### DIFF
--- a/clerk/users.go
+++ b/clerk/users.go
@@ -241,9 +241,9 @@ func (s *UsersService) Update(userId string, updateRequest *UpdateUser) (*User, 
 }
 
 type UpdateUserMetadata struct {
-	PublicMetadata  interface{} `json:"public_metadata"`
-	PrivateMetadata interface{} `json:"private_metadata"`
-	UnsafeMetadata  interface{} `json:"unsafe_metadata"`
+	PublicMetadata  json.RawMessage `json:"public_metadata"`
+	PrivateMetadata json.RawMessage `json:"private_metadata"`
+	UnsafeMetadata  json.RawMessage `json:"unsafe_metadata"`
 }
 
 func (s *UsersService) UpdateMetadata(userId string, updateMetadataRequest *UpdateUserMetadata) (*User, error) {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Fixes issue with incorrect type on UpdateUserMetadata which is currently set to `interface{}` to `json.RawMessage` which is what is needed to make the request work however anything currently passed into it such as a map[string]string is currently valid.

### Related Issue (optional)

https://github.com/clerkinc/clerk-sdk-go/issues/109
