### PR TITLE
chore: Remove deprecated client.sign_in_attempt_id & client.sign_up_attempt_id fields

### DIFF
--- a/clerk/clients.go
+++ b/clerk/clients.go
@@ -10,8 +10,6 @@ type ClientResponse struct {
 	LastActiveSessionID *string    `json:"last_active_session_id"`
 	SessionIDs          []string   `json:"session_ids"`
 	Sessions            []*Session `json:"sessions"`
-	SignInAttemptID     *string    `json:"sign_in_attempt_id"`
-	SignUpAttemptID     *string    `json:"sign_up_attempt_id"`
 	Ended               bool       `json:"ended"`
 }
 

--- a/clerk/clients_test.go
+++ b/clerk/clients_test.go
@@ -130,7 +130,5 @@ const dummyClientResponseJson = `{
 			"status": "ended",
 			"user_id": "user_1mebQggrD3xO5JfuHk7clQ94ysA"
 		}],
-        "object": "client",
-        "sign_in_attempt_id": null,
-        "sign_up_attempt_id": null
+        "object": "client"
     }`


### PR DESCRIPTION
]## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [x] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [x] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

<!--- Describe your changes in detail -->

### Related Issue (optional)

Remove two deprecated fields of client response
- `sign_in_attempt_id`
- `sign_up_attempt_id`