### PR TITLE
fix: SAML Connection response type and accept pagination params

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -355,4 +356,18 @@ func (c *client) Interstitial() ([]byte, error) {
 	}
 
 	return interstitial, nil
+}
+
+type PaginationParams struct {
+	Limit  *int
+	Offset *int
+}
+
+func addPaginationParams(query url.Values, params PaginationParams) {
+	if params.Limit != nil {
+		query.Set("limit", strconv.Itoa(*params.Limit))
+	}
+	if params.Offset != nil {
+		query.Set("offset", strconv.Itoa(*params.Offset))
+	}
 }

--- a/clerk/saml_connections.go
+++ b/clerk/saml_connections.go
@@ -22,14 +22,28 @@ type SAMLConnection struct {
 	UpdatedAt      int64  `json:"updated_at"`
 }
 
-func (s SAMLConnectionsService) ListAll() ([]SAMLConnection, error) {
+type ListSAMLConnectionsResponse struct {
+	Data       []SAMLConnection `json:"data"`
+	TotalCount int64            `json:"total_count"`
+}
+
+type ListSAMLConnectionsParams struct {
+	Limit  *int
+	Offset *int
+}
+
+func (s SAMLConnectionsService) ListAll(params ListSAMLConnectionsParams) (*ListSAMLConnectionsResponse, error) {
 	req, err := s.client.NewRequest(http.MethodGet, SAMLConnectionsUrl)
 	if err != nil {
 		return nil, err
 	}
 
-	samlConnections := make([]SAMLConnection, 0)
-	if _, err = s.client.Do(req, &samlConnections); err != nil {
+	query := req.URL.Query()
+	addPaginationParams(query, PaginationParams{Limit: params.Limit, Offset: params.Offset})
+	req.URL.RawQuery = query.Encode()
+
+	samlConnections := &ListSAMLConnectionsResponse{}
+	if _, err = s.client.Do(req, samlConnections); err != nil {
 		return nil, err
 	}
 

--- a/clerk/saml_connections_test.go
+++ b/clerk/saml_connections_test.go
@@ -14,7 +14,10 @@ func TestSAMLConnectionsService_ListAll(t *testing.T) {
 	c, mux, _, teardown := setup("token")
 	defer teardown()
 
-	dummyResponse := "[" + dummySAMLConnectionJSON + "]"
+	dummyResponse := fmt.Sprintf(`{
+		"data": [%s],
+		"total_count": 1
+	}`, dummySAMLConnectionJSON)
 
 	mux.HandleFunc("/saml_connections", func(w http.ResponseWriter, req *http.Request) {
 		testHttpMethod(t, req, http.MethodGet)
@@ -22,11 +25,11 @@ func TestSAMLConnectionsService_ListAll(t *testing.T) {
 		_, _ = fmt.Fprint(w, dummyResponse)
 	})
 
-	got, err := c.SAMLConnections().ListAll()
+	got, err := c.SAMLConnections().ListAll(ListSAMLConnectionsParams{})
 	assert.Nil(t, err)
 
-	expected := make([]SAMLConnection, 0)
-	_ = json.Unmarshal([]byte(dummyResponse), &expected)
+	expected := &ListSAMLConnectionsResponse{}
+	_ = json.Unmarshal([]byte(dummyResponse), expected)
 
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("Response = %v, want %v", got, expected)

--- a/clerk/users.go
+++ b/clerk/users.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-	"strconv"
 )
 
 type UsersService service
@@ -75,20 +73,6 @@ type CreateUserParams struct {
 	BackupCodes             []string         `json:"backup_codes,omitempty"`
 	// Specified in RFC3339 format
 	CreatedAt *string `json:"created_at,omitempty"`
-}
-
-type PaginationParams struct {
-	Limit  *int
-	Offset *int
-}
-
-func addPaginationParams(query url.Values, params PaginationParams) {
-	if params.Limit != nil {
-		query.Set("limit", strconv.Itoa(*params.Limit))
-	}
-	if params.Offset != nil {
-		query.Set("offset", strconv.Itoa(*params.Offset))
-	}
 }
 
 func (s *UsersService) Create(params CreateUserParams) (*User, error) {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This commit fixes the SAML Connection ListAll() method, to return the proper data (paginated) and to also accept any pagination params that the user might want to use

### Related Issue (optional)

<!--- Please link to the issue here: -->
