### PR TITLE
chore: Removed non-implemented disable sign ups option

### DIFF
--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -49,11 +49,6 @@ type UpdateInstanceParams struct {
 	// URL that is going to be used in development instances in order to create custom redirects
 	// and fix the third-party cookies issues.
 	DevelopmentOrigin *string `json:"development_origin,omitempty"`
-
-	// DisableSignUps can be used to allow or disable sign ups on the current instance.
-	// If they are disabled, users can no longer sign up on their own, but they need
-	// to be manually added by an administrator.
-	DisableSignUps *bool `json:"disable_sign_ups,omitempty"`
 }
 
 func (s *InstanceService) Update(params UpdateInstanceParams) error {

--- a/clerk/instances_test.go
+++ b/clerk/instances_test.go
@@ -23,14 +23,12 @@ func TestInstanceService_Update_happyPath(t *testing.T) {
 	enabled := true
 	supportEmail := "support@clerk.dev"
 	clerkJSVersion := "42"
-	disableSignUps := true
 	err := client.Instances().Update(UpdateInstanceParams{
 		TestMode:                    &enabled,
 		HIBP:                        &enabled,
 		EnhancedEmailDeliverability: &enabled,
 		SupportEmail:                &supportEmail,
 		ClerkJSVersion:              &clerkJSVersion,
-		DisableSignUps:              &disableSignUps,
 	})
 
 	if err != nil {

--- a/tests/integration/instances_test.go
+++ b/tests/integration/instances_test.go
@@ -16,14 +16,12 @@ func TestInstances(t *testing.T) {
 	enabled := true
 	developmentOrigin := "http://localhost:3000"
 	supportEmail := "support@example.com"
-	disableSignUps := false
 	err := client.Instances().Update(clerk.UpdateInstanceParams{
 		TestMode:                    &enabled,
 		HIBP:                        &enabled,
 		EnhancedEmailDeliverability: &enabled,
 		SupportEmail:                &supportEmail,
 		DevelopmentOrigin:           &developmentOrigin,
-		DisableSignUps:              &disableSignUps,
 	})
 	if err != nil {
 		t.Fatalf("Instances.Update returned error: %v", err)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This commit removes the option of disabling sign ups, given that it's a feature that was never implemented and thus not used by anyone.

### Related Issue (optional)

<!--- Please link to the issue here: -->
