### PR TITLE
Include saml connection 'provider', 'user_count' fields and add support for 'query', 'order_by' params in ListAll() method

### DIFF
--- a/clerk/http_utils_test.go
+++ b/clerk/http_utils_test.go
@@ -50,3 +50,11 @@ func testQuery(t *testing.T, r *http.Request, want url.Values) {
 		}
 	}
 }
+
+func stringToPtr(input string) *string {
+	return &input
+}
+
+func intToPtr(input int) *int {
+	return &input
+}

--- a/clerk/http_utils_test.go
+++ b/clerk/http_utils_test.go
@@ -45,9 +45,8 @@ func testQuery(t *testing.T, r *http.Request, want url.Values) {
 	query := r.URL.Query()
 
 	for k := range want {
-		if !query.Has(k) {
+		if query.Get(k) == "" {
 			t.Errorf("Request query doesn't match: have %v, want %v", query, want)
 		}
 	}
-
 }

--- a/clerk/saml_connections.go
+++ b/clerk/saml_connections.go
@@ -18,6 +18,8 @@ type SAMLConnection struct {
 	AcsURL         string `json:"acs_url"`
 	SPEntityID     string `json:"sp_entity_id"`
 	Active         bool   `json:"active"`
+	Provider       string `json:"provider"`
+	UserCount      int64  `json:"user_count"`
 	CreatedAt      int64  `json:"created_at"`
 	UpdatedAt      int64  `json:"updated_at"`
 }
@@ -28,8 +30,10 @@ type ListSAMLConnectionsResponse struct {
 }
 
 type ListSAMLConnectionsParams struct {
-	Limit  *int
-	Offset *int
+	Limit   *int
+	Offset  *int
+	Query   *string
+	OrderBy *string
 }
 
 func (s SAMLConnectionsService) ListAll(params ListSAMLConnectionsParams) (*ListSAMLConnectionsResponse, error) {
@@ -40,6 +44,14 @@ func (s SAMLConnectionsService) ListAll(params ListSAMLConnectionsParams) (*List
 
 	query := req.URL.Query()
 	addPaginationParams(query, PaginationParams{Limit: params.Limit, Offset: params.Offset})
+
+	if params.Query != nil {
+		query.Set("query", *params.Query)
+	}
+	if params.OrderBy != nil {
+		query.Set("order_by", *params.OrderBy)
+	}
+
 	req.URL.RawQuery = query.Encode()
 
 	samlConnections := &ListSAMLConnectionsResponse{}

--- a/clerk/saml_connections_test.go
+++ b/clerk/saml_connections_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -22,10 +23,26 @@ func TestSAMLConnectionsService_ListAll(t *testing.T) {
 	mux.HandleFunc("/saml_connections", func(w http.ResponseWriter, req *http.Request) {
 		testHttpMethod(t, req, http.MethodGet)
 		testHeader(t, req, "Authorization", "Bearer token")
+
+		expectedQuery := url.Values{
+			"limit":    {"5"},
+			"offset":   {"6"},
+			"query":    {"my-query"},
+			"order_by": {"created_at"},
+		}
+		assert.Equal(t, expectedQuery, req.URL.Query())
+
 		_, _ = fmt.Fprint(w, dummyResponse)
 	})
 
-	got, err := c.SAMLConnections().ListAll(ListSAMLConnectionsParams{})
+	listParams := ListSAMLConnectionsParams{
+		Limit:   intToPtr(5),
+		Offset:  intToPtr(6),
+		Query:   stringToPtr("my-query"),
+		OrderBy: stringToPtr("created_at"),
+	}
+
+	got, err := c.SAMLConnections().ListAll(listParams)
 	assert.Nil(t, err)
 
 	expected := &ListSAMLConnectionsResponse{}
@@ -165,7 +182,9 @@ const (
 	"idp_certificate": "` + dummySAMLConnectionCertificate + `",
 	"acs_url": "` + "https://clerk.example.com/v1/saml/acs" + dummySAMLConnectionID + `",
 	"sp_entity_id": "` + "https://clerk.example.com/acs" + dummySAMLConnectionID + `",
-	"active": false
+	"active": false,
+	"provider": "saml_custom",
+	"user_count": 3
 }`
 
 	dummySAMLConnectionUpdatedJSON = `

--- a/clerk/users_test.go
+++ b/clerk/users_test.go
@@ -97,20 +97,16 @@ func TestUsersService_ListAll_happyPathWithParameters(t *testing.T) {
 	var want []User
 	_ = json.Unmarshal([]byte(expectedResponse), &want)
 
-	limit := 5
-	offset := 6
-	queryString := "my-query"
-	orderBy := "created_at"
 	got, _ := client.Users().ListAll(ListAllUsersParams{
-		Limit:          &limit,
-		Offset:         &offset,
+		Limit:          intToPtr(5),
+		Offset:         intToPtr(6),
 		EmailAddresses: []string{"email1", "email2"},
 		PhoneNumbers:   []string{"phone1", "phone2"},
 		Web3Wallets:    []string{"wallet1", "wallet2"},
 		Usernames:      []string{"username1", "username2"},
 		UserIDs:        []string{"userid1", "userid2"},
-		Query:          &queryString,
-		OrderBy:        &orderBy,
+		Query:          stringToPtr("my-query"),
+		OrderBy:        stringToPtr("created_at"),
 	})
 	if len(got) != len(want) {
 		t.Errorf("Was expecting %d user to be returned, instead got %d", len(want), len(got))
@@ -180,14 +176,13 @@ func TestUsersService_Count_happyPathWithParameters(t *testing.T) {
 	var want UserCount
 	_ = json.Unmarshal([]byte(expectedResponse), &want)
 
-	queryString := "my-query"
 	got, _ := client.Users().Count(ListAllUsersParams{
 		EmailAddresses: []string{"email1", "email2"},
 		PhoneNumbers:   []string{"phone1", "phone2"},
 		Web3Wallets:    []string{"wallet1", "wallet2"},
 		Usernames:      []string{"username1", "username2"},
 		UserIDs:        []string{"userid1", "userid2"},
-		Query:          &queryString,
+		Query:          stringToPtr("my-query"),
 	})
 	if !reflect.DeepEqual(*got, want) {
 		t.Errorf("Response = %v, want %v", got, want)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

<!--- Describe your changes in detail -->

### Related Issue (optional)

This PR contains 3 different commits that handle the below:
1. Fix the recent incompatibility change by using the url value [`Has()`](https://pkg.go.dev/net/url#Values.Has) method which was introduced in go1.17 but we are still in go1.16
2. Introduce some handy test helpers to convert int & string types to the equivalent pointer types
3. Include the new saml connection fields `provider`, `user_count` and add support for `query`, `order_by` params in ListAll() method