### PR TITLE
fix: IdP related data are optional during SAML Connection create

### DIFF
--- a/clerk/saml_connections.go
+++ b/clerk/saml_connections.go
@@ -8,21 +8,21 @@ import (
 type SAMLConnectionsService service
 
 type SAMLConnection struct {
-	ID                 string `json:"id"`
-	Object             string `json:"object"`
-	Name               string `json:"name"`
-	Domain             string `json:"domain"`
-	IdpEntityID        string `json:"idp_entity_id"`
-	IdpSsoURL          string `json:"idp_sso_url"`
-	IdpCertificate     string `json:"idp_certificate"`
-	AcsURL             string `json:"acs_url"`
-	SPEntityID         string `json:"sp_entity_id"`
-	Active             bool   `json:"active"`
-	Provider           string `json:"provider"`
-	UserCount          int64  `json:"user_count"`
-	SyncUserAttributes bool   `json:"sync_user_attributes"`
-	CreatedAt          int64  `json:"created_at"`
-	UpdatedAt          int64  `json:"updated_at"`
+	ID                 string  `json:"id"`
+	Object             string  `json:"object"`
+	Name               string  `json:"name"`
+	Domain             string  `json:"domain"`
+	IdpEntityID        *string `json:"idp_entity_id"`
+	IdpSsoURL          *string `json:"idp_sso_url"`
+	IdpCertificate     *string `json:"idp_certificate"`
+	AcsURL             string  `json:"acs_url"`
+	SPEntityID         string  `json:"sp_entity_id"`
+	Active             bool    `json:"active"`
+	Provider           string  `json:"provider"`
+	UserCount          int64   `json:"user_count"`
+	SyncUserAttributes bool    `json:"sync_user_attributes"`
+	CreatedAt          int64   `json:"created_at"`
+	UpdatedAt          int64   `json:"updated_at"`
 }
 
 type ListSAMLConnectionsResponse struct {
@@ -78,11 +78,11 @@ func (s SAMLConnectionsService) Read(id string) (*SAMLConnection, error) {
 }
 
 type CreateSAMLConnectionParams struct {
-	Name           string `json:"name"`
-	Domain         string `json:"domain"`
-	IdpEntityID    string `json:"idp_entity_id"`
-	IdpSsoURL      string `json:"idp_sso_url"`
-	IdpCertificate string `json:"idp_certificate"`
+	Name           string  `json:"name"`
+	Domain         string  `json:"domain"`
+	IdpEntityID    *string `json:"idp_entity_id,omitempty"`
+	IdpSsoURL      *string `json:"idp_sso_url,omitempty"`
+	IdpCertificate *string `json:"idp_certificate,omitempty"`
 }
 
 func (s SAMLConnectionsService) Create(params *CreateSAMLConnectionParams) (*SAMLConnection, error) {

--- a/clerk/saml_connections_test.go
+++ b/clerk/saml_connections_test.go
@@ -43,7 +43,7 @@ func TestSAMLConnectionsService_ListAll(t *testing.T) {
 	}
 
 	got, err := c.SAMLConnections().ListAll(listParams)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expected := &ListSAMLConnectionsResponse{}
 	_ = json.Unmarshal([]byte(dummyResponse), expected)
@@ -68,7 +68,7 @@ func TestSAMLConnectionsService_Read(t *testing.T) {
 	})
 
 	got, err := c.SAMLConnections().Read(dummySAMLConnectionID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expected := SAMLConnection{}
 	_ = json.Unmarshal([]byte(dummyResponse), &expected)
@@ -93,13 +93,13 @@ func TestSAMLConnectionsService_Create(t *testing.T) {
 	createParams := &CreateSAMLConnectionParams{
 		Name:           "Testing SAML",
 		Domain:         "example.com",
-		IdpEntityID:    "test-idp-entity-id",
-		IdpSsoURL:      "https://example.com/saml/sso",
-		IdpCertificate: dummySAMLConnectionCertificate,
+		IdpEntityID:    stringToPtr("test-idp-entity-id"),
+		IdpSsoURL:      stringToPtr("https://example.com/saml/sso"),
+		IdpCertificate: stringToPtr(dummySAMLConnectionCertificate),
 	}
 
 	got, err := c.SAMLConnections().Create(createParams)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expected := SAMLConnection{}
 	_ = json.Unmarshal([]byte(dummyResponse), &expected)
@@ -133,7 +133,7 @@ func TestSAMLConnectionsService_Update(t *testing.T) {
 	}
 
 	got, err := c.SAMLConnections().Update(dummySAMLConnectionID, updateParams)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expected := SAMLConnection{}
 	_ = json.Unmarshal([]byte(dummyResponse), &expected)
@@ -163,7 +163,7 @@ func TestSAMLConnectionsService_Delete(t *testing.T) {
 	}
 
 	got, err := c.SAMLConnections().Delete(dummySAMLConnectionID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	if !reflect.DeepEqual(*got, expected) {
 		t.Errorf("Response = %v, want %v", *got, expected)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [x] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

This commit modifies the SAML Connection create operation params, to convert the IdP related ones (IdpEntityID, IdpSsoURL, IdpCertificate) to optional as we have changed our BAPI endpoints. This is a breaking change, but the feature is still in Beta

### Related Issue (optional)

<!--- Please link to the issue here: -->
