### PR TITLE
fix: Introduce custom string to better handle unset attributes

### DIFF
--- a/clerk/domains.go
+++ b/clerk/domains.go
@@ -36,8 +36,8 @@ type CreateDomainParams struct {
 }
 
 type UpdateDomainParams struct {
-	Name     *string `json:"name,omitempty"`
-	ProxyURL *string `json:"proxy_url,omitempty"`
+	Name     String `json:"name"`
+	ProxyURL String `json:"proxy_url"`
 }
 
 func (s *DomainsService) ListAll() (*DomainListResponse, error) {
@@ -68,8 +68,18 @@ func (s *DomainsService) Update(
 	domainID string,
 	params UpdateDomainParams,
 ) (*Domain, error) {
+	// Transform the update params to for bapi. This way we can ensure that
+	// we do not set unset attributes.
+	bapiParams := struct {
+		Name     *String `json:"name,omitempty"`
+		ProxyURL *String `json:"proxy_url,omitempty"`
+	}{
+		Name:     params.Name.Ptr(),
+		ProxyURL: params.ProxyURL.Ptr(),
+	}
+
 	url := fmt.Sprintf("%s/%s", DomainsURL, domainID)
-	req, _ := s.client.NewRequest(http.MethodPatch, url, &params)
+	req, _ := s.client.NewRequest(http.MethodPatch, url, &bapiParams)
 
 	var domain Domain
 	_, err := s.client.Do(req, &domain)

--- a/clerk/domains_test.go
+++ b/clerk/domains_test.go
@@ -78,7 +78,7 @@ func TestDomainsService_Update_HappyPath(t *testing.T) {
 	name := "foobar.com"
 
 	payload := UpdateDomainParams{
-		Name: &name,
+		Name: NewString(name),
 	}
 
 	client, mux, _, teardown := setup(token)

--- a/clerk/string.go
+++ b/clerk/string.go
@@ -1,0 +1,64 @@
+package clerk
+
+import (
+	"encoding/json"
+)
+
+// String represents all the different states that a value can take
+// in json. It is either an unset attribute, an attribute with a
+// null value or a string.
+type String struct {
+	Value  string
+	IsNull bool
+	IsSet  bool
+}
+
+func NewString(value string) String {
+	return String{
+		Value:  value,
+		IsNull: false,
+		IsSet:  true,
+	}
+}
+
+func NewNullString() String {
+	return String{
+		Value:  "",
+		IsNull: true,
+		IsSet:  true,
+	}
+}
+
+func (s *String) Ptr() *String {
+	if s.IsSet {
+		return s
+	}
+
+	return nil
+}
+
+func (s *String) UnmarshalJSON(data []byte) error {
+	var value interface{}
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+
+	s.IsNull = value == nil
+	if s.IsNull {
+		s.Value = ""
+	} else {
+		s.Value = value.(string)
+	}
+	s.IsSet = true
+
+	return nil
+}
+
+func (s *String) MarshalJSON() ([]byte, error) {
+	// This is called only if attribute is set.
+	if s.IsNull {
+		return json.Marshal(nil)
+	}
+
+	return json.Marshal(&s.Value)
+}

--- a/clerk/string_test.go
+++ b/clerk/string_test.go
@@ -1,0 +1,81 @@
+package clerk
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomStringCommon(t *testing.T) {
+	value := String{}
+	assert.Equal(t, "", value.Value)
+	assert.Equal(t, false, value.IsNull)
+	assert.Equal(t, false, value.IsSet)
+
+	value = NewString("foo")
+	assert.Equal(t, "foo", value.Value)
+	assert.Equal(t, false, value.IsNull)
+	assert.Equal(t, true, value.IsSet)
+
+	value = NewNullString()
+	assert.Equal(t, "", value.Value)
+	assert.Equal(t, true, value.IsNull)
+	assert.Equal(t, true, value.IsSet)
+}
+
+func TestCustomStringJsonDecode(t *testing.T) {
+	jsonPayload := `{
+	"first_name": "foo",
+	"middle_name": null
+}`
+	payload := struct {
+		FirstName  String `json:"first_name"`
+		MiddleName String `json:"middle_name"`
+		LastName   String `json:"last_name"`
+	}{}
+	err := json.NewDecoder(strings.NewReader(jsonPayload)).Decode(&payload)
+	if err != nil {
+		t.Fatalf("failed to decode json: %v\n%v", err, jsonPayload)
+	}
+
+	assert.Equal(t, "foo", payload.FirstName.Value)
+	assert.Equal(t, false, payload.FirstName.IsNull)
+	assert.Equal(t, true, payload.FirstName.IsSet)
+
+	assert.Equal(t, "", payload.MiddleName.Value)
+	assert.Equal(t, true, payload.MiddleName.IsNull)
+	assert.Equal(t, true, payload.MiddleName.IsSet)
+
+	assert.Equal(t, "", payload.LastName.Value)
+	assert.Equal(t, false, payload.LastName.IsNull)
+	assert.Equal(t, false, payload.LastName.IsSet)
+}
+
+func TestCustomStringJsonEncode(t *testing.T) {
+	firstName := NewString("foo")
+	middleName := NewNullString()
+	payload := struct {
+		FirstName  *String `json:"first_name,omitempty"`
+		MiddleName *String `json:"middle_name,omitempty"`
+		LastName   *String `json:"last_name,omitempty"`
+	}{
+		FirstName:  &firstName,
+		MiddleName: &middleName,
+		LastName:   nil,
+	}
+
+	writer := bytes.NewBufferString("")
+	err := json.NewEncoder(writer).Encode(payload)
+	if err != nil {
+		t.Fatalf("failed to encode to json: %v", err)
+	}
+
+	expected := `{
+	"first_name": "foo",
+	"middle_name": null
+}`
+	assert.JSONEq(t, expected, writer.String())
+}

--- a/tests/integration/domains_test.go
+++ b/tests/integration/domains_test.go
@@ -43,7 +43,7 @@ func TestDomains(t *testing.T) {
 
 	name = gofakeit.DomainName()
 	updateDomainParams := clerk.UpdateDomainParams{
-		Name: &name,
+		Name: clerk.NewString(name),
 	}
 
 	domain, err = client.Domains().Update(domain.ID, updateDomainParams)


### PR DESCRIPTION

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

There are 2 separate issues we are trying to solve and both are needed in order to correctly encode and decode a data representation, to and from json, to and from go.

To solve decoding from json and correctly handle the different states a key/value pair can take, we introduce a custom String struct. The custom String can hold set/unset information, null/present information as well as the actual value if present.

The reason this is needed is because there is no other way to avoid the default behavior, which is to handle as same, a missing attribute and a present attribute set to null.

To solve encoding to json and again correctly represent the missing attributes and also support presence as null, we cannot blindly re-purpose the UpdateDomainParams struct which we use for the incoming request.

We use a custom struct that utilizes omitempty to make sure we do not set attributes for the bapi payload that were not set in the incoming dapi payload.

### Related Issue (optional)

Fix USR-261
