### PR TITLE
feat: Block email subaddresses instance setting

### DIFF
--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -65,8 +65,9 @@ type InstanceRestrictionsResponse struct {
 }
 
 type UpdateRestrictionsParams struct {
-	Allowlist *bool `json:"allowlist,omitempty"`
-	Blocklist *bool `json:"blocklist,omitempty"`
+	Allowlist              *bool `json:"allowlist,omitempty"`
+	Blocklist              *bool `json:"blocklist,omitempty"`
+	BlockEmailSubaddresses *bool `json:"block_email_subaddresses,omitempty"`
 }
 
 func (s *InstanceService) UpdateRestrictions(params UpdateRestrictionsParams) (*InstanceRestrictionsResponse, error) {

--- a/clerk/instances_test.go
+++ b/clerk/instances_test.go
@@ -58,7 +58,8 @@ func TestInstanceService_UpdateRestrictions_happyPath(t *testing.T) {
 	token := "token"
 	dummyRestrictionsResponseJSON := `{
 		"allowlist": true,
-		"blocklist": true
+		"blocklist": true,
+		"block_email_subaddresses": true
 	}`
 	var restrictionsResponse InstanceRestrictionsResponse
 	_ = json.Unmarshal([]byte(dummyRestrictionsResponseJSON), &restrictionsResponse)
@@ -74,8 +75,9 @@ func TestInstanceService_UpdateRestrictions_happyPath(t *testing.T) {
 
 	enabled := true
 	got, _ := client.Instances().UpdateRestrictions(UpdateRestrictionsParams{
-		Allowlist: &enabled,
-		Blocklist: &enabled,
+		Allowlist:              &enabled,
+		Blocklist:              &enabled,
+		BlockEmailSubaddresses: &enabled,
 	})
 
 	assert.Equal(t, &restrictionsResponse, got)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Added support for the block_email_subaddresses parameter when updating the instance's restrictrions.

### Related Issue (optional)

<!--- Please link to the issue here: -->
