### PR TITLE
fix: Include block email subaddresses in restrictions response

### DIFF
--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -59,9 +59,10 @@ func (s *InstanceService) Update(params UpdateInstanceParams) error {
 }
 
 type InstanceRestrictionsResponse struct {
-	Object    string `json:"object"`
-	Allowlist bool   `json:"allowlist"`
-	Blocklist bool   `json:"blocklist"`
+	Object                 string `json:"object"`
+	Allowlist              bool   `json:"allowlist"`
+	Blocklist              bool   `json:"blocklist"`
+	BlockEmailSubaddresses bool   `json:"block_email_subaddresses"`
 }
 
 type UpdateRestrictionsParams struct {

--- a/tests/integration/instances_test.go
+++ b/tests/integration/instances_test.go
@@ -39,6 +39,7 @@ func TestInstanceRestrictions(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, restrictionsResponse.Allowlist)
 	assert.True(t, restrictionsResponse.Blocklist)
+	assert.False(t, restrictionsResponse.BlockEmailSubaddresses)
 }
 
 func TestInstanceOrganizationSettings(t *testing.T) {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Added support for the `block_email_subaddresses` key in the instance restrictions response.

I should have been more careful in #150. :disappointed: 

### Related Issue (optional)

<!--- Please link to the issue here: -->
