### PR TITLE
feat: Allow updating organization domain related settings (enable, enrollment modes

### DIFF
--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -83,16 +83,20 @@ func (s *InstanceService) UpdateRestrictions(params UpdateRestrictionsParams) (*
 }
 
 type OrganizationSettingsResponse struct {
-	Object                string `json:"object"`
-	Enabled               bool   `json:"enabled"`
-	MaxAllowedMemberships int    `json:"max_allowed_memberships"`
-	AdminDeleteEnabled    bool   `json:"admin_delete_enabled"`
+	Object                 string   `json:"object"`
+	Enabled                bool     `json:"enabled"`
+	MaxAllowedMemberships  int      `json:"max_allowed_memberships"`
+	AdminDeleteEnabled     bool     `json:"admin_delete_enabled"`
+	DomainsEnabled         bool     `json:"domains_enabled"`
+	DomainsEnrollmentModes []string `json:"domains_enrollment_modes"`
 }
 
 type UpdateOrganizationSettingsParams struct {
-	Enabled               *bool `json:"enabled,omitempty"`
-	MaxAllowedMemberships *int  `json:"max_allowed_memberships,omitempty"`
-	AdminDeleteEnabled    *bool `json:"admin_delete_enabled,omitempty"`
+	Enabled                *bool    `json:"enabled,omitempty"`
+	MaxAllowedMemberships  *int     `json:"max_allowed_memberships,omitempty"`
+	AdminDeleteEnabled     *bool    `json:"admin_delete_enabled,omitempty"`
+	DomainsEnabled         *bool    `json:"domains_enabled,omitempty"`
+	DomainsEnrollmentModes []string `json:"domains_enrollment_modes"`
 }
 
 func (s *InstanceService) UpdateOrganizationSettings(params UpdateOrganizationSettingsParams) (*OrganizationSettingsResponse, error) {

--- a/clerk/instances_test.go
+++ b/clerk/instances_test.go
@@ -100,7 +100,14 @@ func TestInstanceService_UpdateOrganizationSettings_happyPath(t *testing.T) {
 	token := "token"
 	dummyOrganizationSettingsResponseJSON := `{
 		"enabled": true,
-		"max_allowed_memberships": 2
+		"max_allowed_memberships": 2,
+		"admin_delete_enabled": true,
+		"domains_enabled": true,
+		"domains_enrollment_modes": [
+			"manual_invitation",
+			"automatic_invitation",
+			"automatic_suggestion"
+		]
 	}`
 	var organizationSettingsResponse OrganizationSettingsResponse
 	_ = json.Unmarshal([]byte(dummyOrganizationSettingsResponseJSON), &organizationSettingsResponse)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

In this commit we are introducing two new parameters (domains_enabled, domains_enrollment_modes) as part of the update organization settings method, in order to control organization domain related settings

### Related Issue (optional)

<!--- Please link to the issue here: -->
