### PR TITLE
fix: Add omitempty tag on domains_enrollment_modes field of UpdateOrganizationSettings()

### DIFF
--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -96,7 +96,7 @@ type UpdateOrganizationSettingsParams struct {
 	MaxAllowedMemberships  *int     `json:"max_allowed_memberships,omitempty"`
 	AdminDeleteEnabled     *bool    `json:"admin_delete_enabled,omitempty"`
 	DomainsEnabled         *bool    `json:"domains_enabled,omitempty"`
-	DomainsEnrollmentModes []string `json:"domains_enrollment_modes"`
+	DomainsEnrollmentModes []string `json:"domains_enrollment_modes,omitempty"`
 }
 
 func (s *InstanceService) UpdateOrganizationSettings(params UpdateOrganizationSettingsParams) (*OrganizationSettingsResponse, error) {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

We add the omitempty tag on the domains_enrollment_modes field of UpdateOrganizationSettings() method in order the marshaller to not convert the field to 'null' value if not provided

### Related Issue (optional)

<!--- Please link to the issue here: -->
