### PR TITLE
 Modify Issuer verification for all possible scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The new middlewares (`clerk.WithSessionV2()` & `clerk.RequireSessionV2()`) also 
 - clerk.WithLeeway() to set a custom leeway that gives some extra time to the token to accommodate for clock skew
 - clerk.WithJWTVerificationKey() to set the JWK to use for verifying tokens without the need to fetch or cache any JWKs at runtime
 - clerk.WithCustomClaims() to pass a type (e.g. struct), which will be populated with the token claims based on json tags.
+- clerk.WithSatelliteDomain() to skip the JWT token's "iss" claim verification.
+- clerk.WithProxyURL() to verify the JWT token's "iss" claim against the proxy url.
 
 For example
 
@@ -110,6 +112,8 @@ clerk.WithSessionV2(
 	clerk.WithAuthorizedParty("my-authorized-party"),
 	clerk.WithLeeway(5 * time.Second),
 	clerk.WithCustomClaims(&customClaims),
+	clerk.WithSatelliteDomain(true),
+	clerk.WithProxyURL("https://example.com/__clerk"),
 	)
 ```
 

--- a/clerk/middleware.go
+++ b/clerk/middleware.go
@@ -51,7 +51,7 @@ func isAuthV2Request(r *http.Request, client Client) (string, bool) {
 
 	claims, err := client.DecodeToken(headerToken)
 	if err == nil {
-		return headerToken, isValidIssuer(claims.Issuer)
+		return headerToken, newIssuer(claims.Issuer).IsValid()
 	}
 
 	// Verification from header token failed, try with token from cookie
@@ -65,5 +65,5 @@ func isAuthV2Request(r *http.Request, client Client) (string, bool) {
 		return "", false
 	}
 
-	return cookieSession.Value, isValidIssuer(claims.Issuer)
+	return cookieSession.Value, newIssuer(claims.Issuer).IsValid()
 }

--- a/clerk/tokens_issuer.go
+++ b/clerk/tokens_issuer.go
@@ -1,0 +1,38 @@
+package clerk
+
+import "strings"
+
+type issuer struct {
+	iss         string
+	isSatellite bool
+	proxyURL    string
+}
+
+func newIssuer(iss string) *issuer {
+	return &issuer{
+		iss: iss,
+	}
+}
+
+func (iss *issuer) WithSatelliteDomain(isSatellite bool) *issuer {
+	iss.isSatellite = isSatellite
+	return iss
+}
+
+func (iss *issuer) WithProxyURL(proxyURL string) *issuer {
+	iss.proxyURL = proxyURL
+	return iss
+}
+
+func (iss *issuer) IsValid() bool {
+	if iss.isSatellite {
+		return true
+	}
+
+	if iss.proxyURL != "" {
+		return iss.iss == iss.proxyURL
+	}
+
+	return strings.HasPrefix(iss.iss, "https://clerk.") ||
+		strings.Contains(iss.iss, ".clerk.accounts")
+}

--- a/clerk/tokens_options.go
+++ b/clerk/tokens_options.go
@@ -63,6 +63,20 @@ func WithCustomClaims(customClaims interface{}) VerifyTokenOption {
 	}
 }
 
+func WithSatelliteDomain(isSatellite bool) VerifyTokenOption {
+	return func(o *verifyTokenOptions) error {
+		o.isSatellite = isSatellite
+		return nil
+	}
+}
+
+func WithProxyURL(proxyURL string) VerifyTokenOption {
+	return func(o *verifyTokenOptions) error {
+		o.proxyURL = proxyURL
+		return nil
+	}
+}
+
 func pemToJWK(key string) (*jose.JSONWebKey, error) {
 	block, _ := pem.Decode([]byte(key))
 	if block == nil {

--- a/clerk/tokens_options_test.go
+++ b/clerk/tokens_options_test.go
@@ -76,6 +76,28 @@ BQIDAQAB
 	}
 }
 
+func TestWithSatelliteDomain(t *testing.T) {
+	isSatellite := true
+
+	opts := &verifyTokenOptions{}
+	err := WithSatelliteDomain(isSatellite)(opts)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, isSatellite, opts.isSatellite)
+	}
+}
+
+func TestWithProxyURL(t *testing.T) {
+	proxyURL := "url"
+
+	opts := &verifyTokenOptions{}
+	err := WithProxyURL(proxyURL)(opts)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, proxyURL, opts.proxyURL)
+	}
+}
+
 func arrayToMap(t *testing.T, input []string) map[string]struct{} {
 	t.Helper()
 

--- a/clerk/tokens_test.go
+++ b/clerk/tokens_test.go
@@ -204,7 +204,7 @@ func TestClient_VerifyToken_Success_NewIssuerFormat(t *testing.T) {
 	claims := dummySessionClaims
 	claims.Issuer = "https://foo-bar-13.clerk.accounts.dev"
 
-	token, pubKey := testGenerateTokenJWT(t, dummySessionClaims, "kid")
+	token, pubKey := testGenerateTokenJWT(t, claims, "kid")
 
 	client := c.(*client)
 	client.jwksCache.set(testBuildJWKS(t, pubKey, jose.RS256, "kid"))
@@ -214,8 +214,8 @@ func TestClient_VerifyToken_Success_NewIssuerFormat(t *testing.T) {
 		t.Fatalf("Expected no error but got %v", err)
 	}
 
-	if !reflect.DeepEqual(got, &dummySessionClaims) {
-		t.Errorf("Expected %+v, but got %+v", dummySessionClaims, got)
+	if !reflect.DeepEqual(got, &claims) {
+		t.Errorf("Expected %+v, but got %+v", claims, got)
 	}
 }
 


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

The js sdk [1] supports overriding the expected issuer by allowing the
sdk user to set a couple of options.

This makes the issuer verification possible for a couple of non-standard
ways, namely when the customer's fapi sits behind a proxy or when the
domain is not the primary one.

[1] https://github.com/clerkinc/javascript/blob/c7c6912f34874467bc74104690fe9f95491cc10d/packages/backend/src/tokens/interstitialRule.ts#L158-L170

### Related Issue

Fix USR-388
